### PR TITLE
fix: serialize motion samples on main thread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@
 
 - No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
 - Resource changes should keep image files, XIB outlets, screenshot, and Xcode project references aligned.
-- Accelerometer callbacks should not strongly retain the controller; motion updates should remain bounded to the live game screen.
+- Accelerometer callbacks should not strongly retain the controller; each sample should be assigned and integrated together on the main thread, and motion updates should remain bounded to the live game screen.
 - `build.sh` should stay valid for `/bin/sh` because CI and local shells may not invoke bash.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-12
+
+- Assigned each Core Motion sample and advanced gameplay together on the main
+  thread, avoiding cross-thread acceleration state races and stale queued reads.
+
 ## 2026-06-10
 
 - Resolved boundaries and walls before outcome collisions, evaluated exit and

--- a/Maze/APPViewController.m
+++ b/Maze/APPViewController.m
@@ -63,12 +63,15 @@
          if (error != nil || accelerometerData == nil) {
              return;
          }
-         APPViewController *strongSelf = weakSelf;
-         if (strongSelf == nil) {
-             return;
-         }
-         strongSelf.acceleration = accelerometerData.acceleration;
-         [strongSelf performSelectorOnMainThread:@selector(update) withObject:nil waitUntilDone:NO];
+         CMAcceleration acceleration = accelerometerData.acceleration;
+         dispatch_async(dispatch_get_main_queue(), ^{
+             APPViewController *strongSelf = weakSelf;
+             if (strongSelf == nil) {
+                 return;
+             }
+             strongSelf.acceleration = acceleration;
+             [strongSelf update];
+         });
      }];
 
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The checked-in project has no external dependency manifest. Use Xcode for full b
 
 - Open `Maze.xcodeproj` in Xcode, choose the app or sample scheme, and run it on the matching simulator/device.
 - Run `./build.sh` when the required platform toolchain is installed. On hosts without Xcode, the script exits cleanly after reporting that the Xcode build was skipped.
-- This is a local game sample with XIB-wired image assets and CoreMotion movement. Gameplay updates clamp the frame time delta before applying accelerometer velocity, resolve boundary and wall constraints before evaluating the corrected collision frame, stop outcome checks after a win, gate collision alerts while visible, and reset the frame clock after alerts. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
+- This is a local game sample with XIB-wired image assets and CoreMotion movement. Each accelerometer sample is assigned and integrated together on the main thread. Gameplay updates clamp the frame time delta before applying accelerometer velocity, resolve boundary and wall constraints before evaluating the corrected collision frame, stop outcome checks after a win, gate collision alerts while visible, and reset the frame clock after alerts. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
 
 ## Testing and Verification
 
@@ -70,7 +70,7 @@ The `lint`, `test`, and `build` targets intentionally alias the static baseline
 on hosts without the legacy Xcode toolchain, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, validates POSIX shell syntax for `build.sh`, parses plist/XIB/scheme XML, checks PNG resources, verifies Xcode project references, checks corrected collision ordering and candidate-frame use, accelerometer lifecycle, collision alert gating, failure velocity reset behavior, previous position initialization, win completion update guards, alert pause behavior, alert frame clock reset behavior, frame time delta clamping, and weak callback capture guardrails, and guards against debug logging, network, analytics, upload, or persistence behavior.
+The baseline runs `scripts/check-baseline.py`, validates POSIX shell syntax for `build.sh`, parses plist/XIB/scheme XML, checks PNG resources, verifies Xcode project references, checks corrected collision ordering and candidate-frame use, accelerometer lifecycle and main-thread handoff, collision alert gating, failure velocity reset behavior, previous position initialization, win completion update guards, alert pause behavior, alert frame clock reset behavior, frame time delta clamping, and weak callback capture guardrails, and guards against debug logging, network, analytics, upload, or persistence behavior.
 
 Pinned `macos-15` CI runs `make check` and compiles the unsigned app for a
 generic iOS simulator. It does not exercise accelerometer input, alerts,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ Helpful reports include:
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - `build.sh` is part of the supported build surface; keep it POSIX-shell compatible and review any changes to simulator destination, scheme, or signing behavior.
 - `build.sh` should skip cleanly on hosts without Xcode instead of failing after partial setup.
-- Accelerometer callbacks should avoid retaining the gameplay controller after the screen is gone; motion updates must remain tied to the live controller lifecycle.
+- Accelerometer callbacks should avoid retaining the gameplay controller after the screen is gone; motion samples must be assigned and integrated together on the main thread, and updates must remain tied to the live controller lifecycle.
 - Collision alerts should stay gated while visible so repeated collision frames do not stack duplicate modal prompts, failure collision handling should apply a velocity reset before prompting, previous position initialization should keep wall-collision rollback aligned with the starting point, win completion should stop future movement updates after the exit alert, alert pause behavior should stop movement updates behind those prompts, and alert dismissal should reset the frame clock before movement resumes.
 - Boundary and wall constraints should be resolved before exit and ghost outcomes, which must use the corrected candidate frame and stop after a terminal win.
 - `make check` runs a static baseline that guards image/XIB references, plist/scheme metadata, Xcode project wiring, shell syntax, source inventory, and local-only gameplay behavior when Xcode is unavailable.

--- a/VISION.md
+++ b/VISION.md
@@ -19,6 +19,7 @@ Priority:
 - Keep the screenshot and README aligned with app behavior
 - Maintain the build script and Xcode project structure
 - Keep accelerometer updates bounded to the live controller lifecycle
+- Assign and integrate each accelerometer sample together on the main thread
 - Gate collision alerts so repeated frames do not stack modal alerts
 - Reset movement velocity after failure collisions send the player to start
 - Keep previous position initialized for wall-collision rollback
@@ -61,7 +62,7 @@ Current baseline: `make lint`, `make test`, `make build`, and `make check` run
 `scripts/check-baseline.py` without Xcode, while hosted macOS CI also compiles
 the unsigned app for a generic iOS simulator. The baseline verifies `build.sh`,
 plist/XIB/scheme XML, image resources, Xcode project references, accelerometer
-lifecycle guardrails, frame time delta clamping, collision alert gating, failure
+lifecycle and main-thread handoff guardrails, frame time delta clamping, collision alert gating, failure
 velocity reset behavior, previous position initialization, win completion update
 guarding, and alert pause behavior, with local-only gameplay and alert frame
 clock reset behavior, with no debug logging, network, analytics, upload, or

--- a/docs/plans/2026-06-12-main-thread-motion-handoff.md
+++ b/docs/plans/2026-06-12-main-thread-motion-handoff.md
@@ -1,6 +1,6 @@
 # Main-Thread Motion Handoff
 
-status: planned
+status: completed
 
 ## Context
 
@@ -10,7 +10,7 @@ and separately schedules `update` on the main thread. Gameplay therefore reads
 a multi-value motion sample on a different thread from the one that wrote it,
 and a newer callback can replace the sample before an older queued update runs.
 
-## Scope
+## Completed Scope
 
 - Dispatch each valid accelerometer sample to the main queue.
 - Resolve the weak controller reference inside the main-queue block.
@@ -27,3 +27,5 @@ and a newer callback can replace the sample before an older queued update runs.
 - `make check`
 - `python3 -m py_compile scripts/check-baseline.py`
 - `git diff --check`
+- Mutation result: moving the acceleration assignment outside the main-queue
+  block was rejected by `scripts/check-baseline.py`.

--- a/docs/plans/2026-06-12-main-thread-motion-handoff.md
+++ b/docs/plans/2026-06-12-main-thread-motion-handoff.md
@@ -1,0 +1,29 @@
+# Main-Thread Motion Handoff
+
+status: planned
+
+## Context
+
+Core Motion invokes the accelerometer handler on the controller's operation
+queue. The current handler writes the `CMAcceleration` property on that queue
+and separately schedules `update` on the main thread. Gameplay therefore reads
+a multi-value motion sample on a different thread from the one that wrote it,
+and a newer callback can replace the sample before an older queued update runs.
+
+## Scope
+
+- Dispatch each valid accelerometer sample to the main queue.
+- Resolve the weak controller reference inside the main-queue block.
+- Assign the sample and run the gameplay update together on the main thread.
+- Extend the static baseline and project documentation with this invariant.
+- Mutation-test that moving the assignment outside the main-queue block is
+  rejected.
+
+## Verification
+
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `python3 -m py_compile scripts/check-baseline.py`
+- `git diff --check`

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -22,6 +22,7 @@ PREVIOUS_POINT_PLAN = ROOT / "docs/plans/2026-06-10-previous-point-initializatio
 CI_PLAN = ROOT / "docs/plans/2026-06-10-ci-baseline.md"
 HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation.md"
 CORRECTED_COLLISION_PLAN = ROOT / "docs/plans/2026-06-10-corrected-collision-build.md"
+MAIN_THREAD_MOTION_PLAN = ROOT / "docs/plans/2026-06-12-main-thread-motion-handoff.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -110,6 +111,7 @@ def main():
         "docs/plans/2026-06-10-ci-baseline.md",
         "docs/plans/2026-06-10-hosted-project-validation.md",
         "docs/plans/2026-06-10-corrected-collision-build.md",
+        "docs/plans/2026-06-12-main-thread-motion-handoff.md",
         "docs/readme-overview.svg",
     ]
 
@@ -165,6 +167,7 @@ def main():
     ci_plan = CI_PLAN.read_text(encoding="utf-8") if CI_PLAN.exists() else ""
     hosted_validation_plan = HOSTED_VALIDATION_PLAN.read_text(encoding="utf-8") if HOSTED_VALIDATION_PLAN.exists() else ""
     corrected_collision_plan = CORRECTED_COLLISION_PLAN.read_text(encoding="utf-8") if CORRECTED_COLLISION_PLAN.exists() else ""
+    main_thread_motion_plan = MAIN_THREAD_MOTION_PLAN.read_text(encoding="utf-8") if MAIN_THREAD_MOTION_PLAN.exists() else ""
 
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
@@ -211,10 +214,17 @@ def main():
     require("error != nil || accelerometerData == nil" in source and "- (void)dealloc" in source,
             "Objective-C source must ignore unavailable motion samples and stop updates during teardown",
             failures)
+    sample_capture_index = view_controller.find("CMAcceleration acceleration = accelerometerData.acceleration;")
+    main_dispatch_index = view_controller.find("dispatch_async(dispatch_get_main_queue(), ^{")
+    strong_capture_index = view_controller.find("APPViewController *strongSelf = weakSelf;", main_dispatch_index)
+    sample_assignment_index = view_controller.find("strongSelf.acceleration = acceleration;", main_dispatch_index)
+    update_index = view_controller.find("[strongSelf update];", main_dispatch_index)
     require("__weak APPViewController *weakSelf = self;" in source and
-            "APPViewController *strongSelf = weakSelf;" in source and
-            "strongSelf.acceleration = accelerometerData.acceleration;" in source,
-            "accelerometer callback must avoid strongly retaining the view controller",
+            sample_capture_index != -1 and main_dispatch_index != -1 and
+            strong_capture_index != -1 and sample_assignment_index != -1 and update_index != -1 and
+            sample_capture_index < main_dispatch_index < strong_capture_index < sample_assignment_index < update_index and
+            "performSelectorOnMainThread" not in source,
+            "accelerometer samples must resolve weak capture, assign state, and update together on the main thread",
             failures)
     require("NSTimeInterval secondsSinceLastDraw = -([self.lastUpdateTime timeIntervalSinceNow]);" in source and
             "secondsSinceLastDraw = MAX(0, MIN(secondsSinceLastDraw, 0.1));" in source,
@@ -416,6 +426,8 @@ def main():
             "hosted validation plan must document completed Python and simulator validation", failures)
     require("status: completed" in corrected_collision_plan and "generic iOS simulator" in corrected_collision_plan,
             "corrected collision build plan must be completed", failures)
+    require("status: completed" in main_thread_motion_plan and "mutation" in main_thread_motion_plan.lower(),
+            "main-thread motion handoff plan must record completed mutation verification", failures)
     require(ci_workflow.count("permissions:\n  contents: read") == 1 and
             not re.search(r"(?m)^\s{2,}permissions:\s*$", ci_workflow) and
             not re.search(r"(?m)^\s+[A-Za-z0-9_-]+:\s*write\s*$", ci_workflow) and


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: serialize motion samples on main thread

### Original Description

### Summary

- capture each valid Core Motion sample by value
- resolve the weak controller reference, assign acceleration, and run gameplay together on the main queue
- extend the baseline and documentation to reject cross-thread acceleration state writes

## Verification

- `make lint`
- `make test`
- `make build`
- `make check`
- `python3 -m py_compile scripts/check-baseline.py`
- `git diff --check`
- mutation proof: moving the acceleration assignment outside the main-queue block is rejected

## Runtime note

This Linux checkout cannot run Xcode or exercise live accelerometer delivery. The hosted macOS workflow compiles the unsigned generic-simulator app; device-level motion remains a manual gameplay check.

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the motion validation, gameplay lifecycle, resource integrity, build, CI, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted evidence is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, motion data, resource, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; live accelerometer and gameplay interaction remain bounded by the exact-head evidence.
