### PR TITLE
Document motion handoff verification

### DIFF
--- a/docs/plans/2026-06-12-main-thread-motion-handoff.md
+++ b/docs/plans/2026-06-12-main-thread-motion-handoff.md
@@ -10,7 +10,7 @@ and separately schedules `update` on the main thread. Gameplay therefore reads
 a multi-value motion sample on a different thread from the one that wrote it,
 and a newer callback can replace the sample before an older queued update runs.
 
-## Completed Scope
+## Work Completed
 
 - Dispatch each valid accelerometer sample to the main queue.
 - Resolve the weak controller reference inside the main-queue block.
@@ -19,13 +19,25 @@ and a newer callback can replace the sample before an older queued update runs.
 - Mutation-test that moving the assignment outside the main-queue block is
   rejected.
 
-## Verification
+## Verification Completed
 
-- `make lint`
-- `make test`
-- `make build`
-- `make check`
-- `python3 -m py_compile scripts/check-baseline.py`
-- `git diff --check`
-- Mutation result: moving the acceleration assignment outside the main-queue
-  block was rejected by `scripts/check-baseline.py`.
+- Local `make check`, `make lint`, `make test`, and `make build` passed. The
+  local environment did not provide `xcodebuild`, so `build.sh` reported the
+  hosted Xcode requirement after the complete static baseline passed.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, and
+  `git diff --check` passed.
+- Hostile mutations changing the plan status, inserting an unfinished-work
+  marker, falsifying a run ID, moving the acceleration assignment outside the
+  main-queue block, or resolving the controller before dispatch were rejected.
+- The implementation push Check run `27395230698` completed successfully for
+  commit `6e06f5d1a53d3b471d192b34c2c1af70d16b4b7e`.
+- The implementation pull-request Check run `27395235753` completed
+  successfully for commit `6e06f5d1a53d3b471d192b34c2c1af70d16b4b7e` and
+  built the Objective-C target for the generic iOS simulator on hosted macOS.
+- The post-merge push Check run `27395277519` completed successfully for
+  commit `0478d9fc14bf406ce0df7d5c8362e9477075951c`.
+- The CodeQL setup run `27402323504` completed successfully for commit
+  `0478d9fc14bf406ce0df7d5c8362e9477075951c`.
+- Motion handling preserves `dispatch_async(dispatch_get_main_queue(), ^{`,
+  then `APPViewController *strongSelf = weakSelf;`,
+  `strongSelf.acceleration = acceleration;`, and `[strongSelf update];`.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -35,6 +35,14 @@ def read(relative_path):
     return (ROOT / relative_path).read_text(encoding="utf-8", errors="replace")
 
 
+def markdown_section(text, heading):
+    match = re.search(
+        rf"(?ms)^## {re.escape(heading)}\s*$\n(.*?)(?=^## |\Z)",
+        text,
+    )
+    return match.group(1).strip() if match else ""
+
+
 def strip_c_line_comments(text):
     return "\n".join(line.split("//", 1)[0] for line in text.splitlines())
 
@@ -426,8 +434,42 @@ def main():
             "hosted validation plan must document completed Python and simulator validation", failures)
     require("status: completed" in corrected_collision_plan and "generic iOS simulator" in corrected_collision_plan,
             "corrected collision build plan must be completed", failures)
-    require("status: completed" in main_thread_motion_plan and "mutation" in main_thread_motion_plan.lower(),
-            "main-thread motion handoff plan must record completed mutation verification", failures)
+    main_thread_motion_status = re.findall(
+        r"(?mi)^status:\s*(.+?)\s*$", main_thread_motion_plan
+    )
+    main_thread_motion_work = markdown_section(main_thread_motion_plan, "Work Completed")
+    main_thread_motion_verification = markdown_section(
+        main_thread_motion_plan, "Verification Completed"
+    )
+    require(main_thread_motion_status == ["completed"] and main_thread_motion_work,
+            "main-thread motion handoff plan must record one completed status and completed work",
+            failures)
+    require(main_thread_motion_verification and
+            not re.search(r"(?i)\b(?:pending|todo|tbd|not run)\b", main_thread_motion_verification),
+            "main-thread motion handoff plan must record finished verification without pending markers",
+            failures)
+    for evidence in [
+        "make check",
+        "make lint",
+        "make test",
+        "make build",
+        "python3 -m py_compile scripts/check-baseline.py",
+        "sh -n build.sh",
+        "git diff --check",
+        "27395230698",
+        "27395235753",
+        "27395277519",
+        "27402323504",
+        "6e06f5d1a53d3b471d192b34c2c1af70d16b4b7e",
+        "0478d9fc14bf406ce0df7d5c8362e9477075951c",
+        "dispatch_async(dispatch_get_main_queue(), ^{",
+        "APPViewController *strongSelf = weakSelf;",
+        "strongSelf.acceleration = acceleration;",
+        "[strongSelf update];",
+    ]:
+        require(evidence in main_thread_motion_verification,
+                f"main-thread motion handoff plan must preserve verification evidence: {evidence}",
+                failures)
     require(ci_workflow.count("permissions:\n  contents: read") == 1 and
             not re.search(r"(?m)^\s{2,}permissions:\s*$", ci_workflow) and
             not re.search(r"(?m)^\s+[A-Za-z0-9_-]+:\s*write\s*$", ci_workflow) and


### PR DESCRIPTION
## Summary
Document the completed main-thread motion handoff with exact hosted evidence and enforce that evidence in the canonical baseline.

## Baseline
The merged implementation captures each motion sample off-thread, then resolves the controller, assigns acceleration, and runs the update together on the main queue. Historical push, pull-request, post-merge, and CodeQL runs are successful.

## Improvements
- Record exact run IDs and commit SHAs in the completed plan.
- Require one completed status and a finished verification section.
- Preserve dispatch, weak-to-strong resolution, assignment, and update ordering.
- Reject five hostile plan and Objective-C mutations.

## Validation
- `make check`
- `make lint`
- `make test`
- `make build`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- `git diff --check`
- Five hostile mutations rejected

## Risk
Local Linux cannot run Xcode. The canonical hosted macOS Check builds the Objective-C target for a generic iOS simulator; this documentation-only follow-up does not change gameplay behavior.

## Follow-Ups
Keep PR #4 open for owner review. Do not merge without explicit authorization, and require exact-head push, pull-request, and CodeQL success.