### PR TITLE
fix: make pacman checks location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made all Make verification aliases location-independent when invoked through
+  an absolute Makefile path.
 - Rejected non-finite motion samples before main-thread gameplay assignment and
   update.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	python3 scripts/check-baseline.py
-	./build.sh
+	python3 "$(ROOT)/scripts/check-baseline.py"
+	cd "$(ROOT)" && ./build.sh

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   baseline.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.
 - Run `make lint`, `make test`, `make build`, and `make check` before pushing changes to Objective-C sources, plist/XIB files, image assets, Xcode metadata, `build.sh`, or gameplay/security documentation.
+- The same gates may be invoked through an absolute Makefile path from another
+  directory; verification resolves both commands relative to the checkout.
 
 ## Contributing
 

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,33 @@
+# Location-Independent Pacman Verification
+
+status: in progress
+
+## Context
+
+Absolute Makefile invocations resolve both the Python checker and `build.sh`
+relative to the caller instead of the checkout, so documented verification
+aliases fail outside the repository directory.
+
+## Scope
+
+1. Derive the checkout root from the loaded Makefile.
+2. Invoke the checker by absolute path and enter the checkout before `build.sh`.
+3. Add exact Makefile, completed-plan, external-run, and guidance contracts.
+4. Preserve Objective-C gameplay, project metadata, resources, and workflow
+   policy.
+
+## Verification Plan
+
+- Run all four Make gates from the checkout and through an absolute Makefile
+  path from a temporary directory.
+- Run checker compilation, build-script syntax, project metadata parsing, and
+  diff checks.
+- Reject root-derivation, checker-invocation, build-script-invocation,
+  plan-status, plan-evidence, and documentation mutations independently.
+- Inspect intended paths, secret patterns, conflict markers, and generated
+  artifacts before commit.
+
+## Risk And Rollback
+
+This changes verification path resolution only. Rollback restores the relative
+recipes and removes their checker, plan, and documentation contracts.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,12 +1,12 @@
 # Location-Independent Pacman Verification
 
-status: in progress
+status: completed
 
 ## Context
 
-Absolute Makefile invocations resolve both the Python checker and `build.sh`
-relative to the caller instead of the checkout, so documented verification
-aliases fail outside the repository directory.
+Absolute Makefile invocations previously resolved both the Python checker and
+`build.sh` relative to the caller instead of the checkout, so documented
+verification aliases failed outside the repository directory.
 
 ## Scope
 
@@ -26,6 +26,25 @@ aliases fail outside the repository directory.
   plan-status, plan-evidence, and documentation mutations independently.
 - Inspect intended paths, secret patterns, conflict markers, and generated
   artifacts before commit.
+
+## Work Completed
+
+- Derived the checkout root from the loaded Makefile, invoked the checker by
+  absolute path, and entered the checkout before running `build.sh`.
+- Added exact Makefile, completed-plan, external-run, and synchronized guidance
+  contracts without changing gameplay, project, resources, or workflow files.
+
+## Verification Completed
+
+- All four Make gates passed from the checkout.
+- All four Make gates passed from `/tmp` through the absolute Makefile path.
+- `python3 -m py_compile scripts/check-baseline.py`, `sh -n build.sh`, and
+  project metadata parsing passed; `git diff --check` passed.
+- Local validation reported that `xcodebuild` was unavailable, so the static
+  iOS baseline ran and the build script skipped the Xcode build.
+- Six isolated hostile mutations were rejected: root derivation, checker
+  invocation, build-script invocation, plan status, plan evidence, and
+  documentation guidance.
 
 ## Risk And Rollback
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -24,6 +24,7 @@ HOSTED_VALIDATION_PLAN = ROOT / "docs/plans/2026-06-10-hosted-project-validation
 CORRECTED_COLLISION_PLAN = ROOT / "docs/plans/2026-06-10-corrected-collision-build.md"
 MAIN_THREAD_MOTION_PLAN = ROOT / "docs/plans/2026-06-12-main-thread-motion-handoff.md"
 FINITE_MOTION_PLAN = ROOT / "docs/plans/2026-06-13-nonfinite-motion-sample-guard.md"
+LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -122,6 +123,7 @@ def main():
         "docs/plans/2026-06-10-corrected-collision-build.md",
         "docs/plans/2026-06-12-main-thread-motion-handoff.md",
         "docs/plans/2026-06-13-nonfinite-motion-sample-guard.md",
+        "docs/plans/2026-06-13-location-independent-make.md",
         "docs/readme-overview.svg",
     ]
 
@@ -179,6 +181,7 @@ def main():
     corrected_collision_plan = CORRECTED_COLLISION_PLAN.read_text(encoding="utf-8") if CORRECTED_COLLISION_PLAN.exists() else ""
     main_thread_motion_plan = MAIN_THREAD_MOTION_PLAN.read_text(encoding="utf-8") if MAIN_THREAD_MOTION_PLAN.exists() else ""
     finite_motion_plan = FINITE_MOTION_PLAN.read_text(encoding="utf-8") if FINITE_MOTION_PLAN.exists() else ""
+    location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
 
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
@@ -319,9 +322,13 @@ def main():
     require("*.local.xcconfig" in gitignore and ".env" in gitignore and "DerivedData" in gitignore,
             ".gitignore must exclude local config and Xcode build products",
             failures)
-    require(".PHONY: build check lint test" in makefile and "lint test build: check" in makefile and
-            "check:\n\tpython3 scripts/check-baseline.py\n\t./build.sh" in makefile,
-            "Makefile must expose lint, test, and build aliases and compile through the check gate when Xcode is available",
+    require(".PHONY: build check lint test" in makefile and
+            "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
+            "lint test build: check" in makefile and
+            'check:\n\tpython3 "$(ROOT)/scripts/check-baseline.py"\n\tcd "$(ROOT)" && ./build.sh' in makefile and
+            "python3 scripts/check-baseline.py" not in makefile and
+            "\n\t./build.sh" not in makefile,
+            "Makefile must expose location-independent aliases and compile through the check gate when Xcode is available",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "build.sh" in readme and "Maze.xcodeproj" in readme,
             "README must document static verification, build script, and project usage",
@@ -457,6 +464,30 @@ def main():
             "All four Make gates" in finite_motion_plan and
             "hostile mutations" in finite_motion_plan.lower(),
             "non-finite motion sample plan must record completed status and verification",
+            failures)
+    location_make_statuses = re.findall(
+        r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE
+    )
+    location_make_verification = markdown_section(
+        location_independent_make_plan, "Verification Completed"
+    )
+    require(location_make_statuses == ["status: completed"] and
+            "All four Make gates passed from the checkout" in location_make_verification and
+            "All four Make gates passed from `/tmp` through the absolute Makefile path" in location_make_verification and
+            "python3 -m py_compile scripts/check-baseline.py" in location_make_verification and
+            "sh -n build.sh" in location_make_verification and
+            "project metadata parsing" in location_make_verification and
+            "git diff --check" in location_make_verification and
+            "`xcodebuild` was unavailable" in location_make_verification and
+            "Six isolated hostile mutations were rejected" in location_make_verification and
+            re.search(r"\b(?:pending|todo|tbd|not run)\b",
+                      location_make_verification,
+                      re.IGNORECASE) is None,
+            "location-independent Make plan must record completed status and actual local verification",
+            failures)
+    require("absolute makefile path" in readme.lower() and
+            "location-independent" in changes.lower(),
+            "README and CHANGES must document location-independent Make verification",
             failures)
     main_thread_motion_status = re.findall(
         r"(?mi)^status:\s*(.+?)\s*$", main_thread_motion_plan


### PR DESCRIPTION
## Summary

The documented Make gates now work when called through an absolute Makefile path from outside the checkout. Verification roots both the Python checker and `build.sh`, while static contracts prevent either command or the completed evidence from regressing.

## Baseline

- The Python checker and `build.sh` invocation previously depended on the caller's working directory.
- Full Xcode build execution is unavailable in the local Linux environment.
- Gameplay behavior, project sources, dependencies, and workflows remain outside this verification-focused change.

## Improvements

- Derive the repository root from the loaded Makefile.
- Root both the Python checker and `build.sh` to the checkout.
- Add static contracts protecting command invocation and completed-plan evidence from regression.

## Validation

- All four Make gates passed from the checkout and from `/tmp`
- Project plist, XML, and workflow YAML parsing passed
- Checker compilation, `build.sh` syntax, and `git diff --check` passed
- Six isolated hostile mutations were rejected
- Intended-path, secret-pattern, conflict-marker, and generated-artifact audits passed
- Local Linux validation truthfully skipped `xcodebuild`

## Risk

- Full Xcode compilation and runtime behavior were not validated locally because the available environment is Linux.
- This PR is stacked on PR #5 (`lfg/ios-pacman-motion-finite-guard-20260613`) and must not be merged independently.

## Follow-Ups

- Preserve and merge PR #5 first, or rebase this work before independent delivery.
- Run the Xcode build and relevant simulator/device checks in a supported macOS environment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
