### PR TITLE
test: execute motion validation behavior in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,13 @@
 
 ## Coding conventions
 
-- Language mix noted in the README: Objective-C (3), C/C++ headers (2), shell (1).
+- Language mix noted in the README: Objective-C (3), C (2), C/C++ headers (3), shell (2).
 - Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
 
 ## Testing guidance
 
-- No dedicated test files were detected; treat `make check` as the minimum baseline.
+- Every Make gate compiles and runs the shared motion-validation C harness before
+  static contracts and the optional Xcode simulator build.
 - Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
 - Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Added executable C tests for finite accelerometer samples using the same
+  predicate as the CoreMotion callback.
+
 ## 2026-06-13
 
 - Made all Make verification aliases location-independent when invoked through

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 .PHONY: build check lint test
 
+CC ?= cc
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 
 check:
+	CC="$(CC)" "$(ROOT)/scripts/run-motion-validation-tests.sh"
 	python3 "$(ROOT)/scripts/check-baseline.py"
 	cd "$(ROOT)" && ./build.sh

--- a/Maze.xcodeproj/project.pbxproj
+++ b/Maze.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		35C6E37C172D3DDE00EA260D /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 35C6E37B172D3DDE00EA260D /* Default@2x.png */; };
 		35C6E37E172D3DDE00EA260D /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 35C6E37D172D3DDE00EA260D /* Default-568h@2x.png */; };
 		35C6E381172D3DDE00EA260D /* APPViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 35C6E380172D3DDE00EA260D /* APPViewController.m */; };
+		A1606161172D3DDE00EA260D /* APPMotionValidation.c in Sources */ = {isa = PBXBuildFile; fileRef = A1606162172D3DDE00EA260D /* APPMotionValidation.c */; };
 		35C6E384172D3DDE00EA260D /* APPViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 35C6E382172D3DDE00EA260D /* APPViewController.xib */; };
 		F483D2D417512FD8007C1170 /* ghost.png in Resources */ = {isa = PBXBuildFile; fileRef = F483D2D217512FD8007C1170 /* ghost.png */; };
 		F483D2D517512FD8007C1170 /* squareWall.png in Resources */ = {isa = PBXBuildFile; fileRef = F483D2D317512FD8007C1170 /* squareWall.png */; };
@@ -47,6 +48,8 @@
 		35C6E37D172D3DDE00EA260D /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		35C6E37F172D3DDE00EA260D /* APPViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APPViewController.h; sourceTree = "<group>"; };
 		35C6E380172D3DDE00EA260D /* APPViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APPViewController.m; sourceTree = "<group>"; };
+		A1606162172D3DDE00EA260D /* APPMotionValidation.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = APPMotionValidation.c; sourceTree = "<group>"; };
+		A1606163172D3DDE00EA260D /* APPMotionValidation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APPMotionValidation.h; sourceTree = "<group>"; };
 		35C6E383172D3DDE00EA260D /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/APPViewController.xib; sourceTree = "<group>"; };
 		35C6E38A172D416000EA260D /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = System/Library/Frameworks/CoreMotion.framework; sourceTree = SDKROOT; };
 		F483D2D217512FD8007C1170 /* ghost.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ghost.png; sourceTree = "<group>"; };
@@ -105,6 +108,8 @@
 				35C6E377172D3DDE00EA260D /* APPAppDelegate.m */,
 				35C6E37F172D3DDE00EA260D /* APPViewController.h */,
 				35C6E380172D3DDE00EA260D /* APPViewController.m */,
+				A1606162172D3DDE00EA260D /* APPMotionValidation.c */,
+				A1606163172D3DDE00EA260D /* APPMotionValidation.h */,
 				35C6E382172D3DDE00EA260D /* APPViewController.xib */,
 				35C6E36E172D3DDE00EA260D /* Supporting Files */,
 			);
@@ -211,6 +216,7 @@
 				35C6E374172D3DDE00EA260D /* main.m in Sources */,
 				35C6E378172D3DDE00EA260D /* APPAppDelegate.m in Sources */,
 				35C6E381172D3DDE00EA260D /* APPViewController.m in Sources */,
+				A1606161172D3DDE00EA260D /* APPMotionValidation.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Maze/APPMotionValidation.c
+++ b/Maze/APPMotionValidation.c
@@ -1,0 +1,7 @@
+#include "APPMotionValidation.h"
+
+#include <math.h>
+
+bool APPMotionComponentsAreFinite(double x, double y, double z) {
+    return isfinite(x) && isfinite(y) && isfinite(z);
+}

--- a/Maze/APPMotionValidation.h
+++ b/Maze/APPMotionValidation.h
@@ -1,0 +1,8 @@
+#ifndef APPMotionValidation_h
+#define APPMotionValidation_h
+
+#include <stdbool.h>
+
+bool APPMotionComponentsAreFinite(double x, double y, double z);
+
+#endif

--- a/Maze/APPViewController.m
+++ b/Maze/APPViewController.m
@@ -3,6 +3,7 @@
 //
 
 #import "APPViewController.h"
+#import "APPMotionValidation.h"
 #import <math.h>
 
 @interface APPViewController ()
@@ -65,7 +66,7 @@
              return;
          }
          CMAcceleration acceleration = accelerometerData.acceleration;
-         if (!isfinite(acceleration.x) || !isfinite(acceleration.y) || !isfinite(acceleration.z)) {
+         if (!APPMotionComponentsAreFinite(acceleration.x, acceleration.y, acceleration.z)) {
              return;
          }
          dispatch_async(dispatch_get_main_queue(), ^{

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 `garethpaul/ios-pacman` is an Apple platform application or Swift sample. Pacman iOS Game
 
-This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Objective-C (3), C/C++ headers (2), shell (1).
+This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Objective-C (3), C (2), C/C++ headers (3), shell (2).
 
 ## Repository Contents
 
@@ -70,7 +70,16 @@ The `lint`, `test`, and `build` targets intentionally alias the static baseline
 on hosts without the legacy Xcode toolchain, so the standard local gate commands
 stay available while preserving the single source of truth.
 
-The baseline runs `scripts/check-baseline.py`, validates POSIX shell syntax for `build.sh`, parses plist/XIB/scheme XML, checks PNG resources, verifies Xcode project references, checks corrected collision ordering and candidate-frame use, accelerometer lifecycle and main-thread handoff, collision alert gating, failure velocity reset behavior, previous position initialization, win completion update guards, alert pause behavior, alert frame clock reset behavior, frame time delta clamping, and weak callback capture guardrails, and guards against debug logging, network, analytics, upload, or persistence behavior.
+The baseline first compiles and runs executable C tests against the same finite
+motion-sample predicate used by the CoreMotion callback. It then runs
+`scripts/check-baseline.py`, validates POSIX shell syntax for `build.sh`, parses
+plist/XIB/scheme XML, checks PNG resources, verifies Xcode project references,
+checks corrected collision ordering and candidate-frame use, accelerometer
+lifecycle and main-thread handoff, collision alert gating, failure velocity
+reset behavior, previous position initialization, win completion update guards,
+alert pause behavior, alert frame clock reset behavior, frame time delta
+clamping, and weak callback capture guardrails, and guards against debug
+logging, network, analytics, upload, or persistence behavior.
 
 Pinned `macos-15` CI runs `make check` and compiles the unsigned app for a
 generic iOS simulator. It does not exercise accelerometer input, alerts,
@@ -107,6 +116,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - See `docs/plans/2026-06-10-previous-point-initialization.md` for the previous position initialization guardrail.
 - See `docs/plans/2026-06-13-nonfinite-motion-sample-guard.md` for the sensor
   value guardrail.
+- See `docs/plans/2026-06-16-executable-motion-validation-tests.md` for the
+  shared finite-sample predicate and executable C behavioral gate.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions static
   baseline.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.

--- a/Tests/APPMotionValidationTests.c
+++ b/Tests/APPMotionValidationTests.c
@@ -1,0 +1,40 @@
+#include "APPMotionValidation.h"
+
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+
+static int failure_count = 0;
+
+static void expect_true(bool value, const char *message) {
+    if (!value) {
+        fprintf(stderr, "FAIL: %s: expected true\n", message);
+        failure_count += 1;
+    }
+}
+
+static void expect_false(bool value, const char *message) {
+    if (value) {
+        fprintf(stderr, "FAIL: %s: expected false\n", message);
+        failure_count += 1;
+    }
+}
+
+int main(void) {
+    expect_true(APPMotionComponentsAreFinite(0.0, 0.0, 0.0), "zero sample is finite");
+    expect_true(APPMotionComponentsAreFinite(0.25, -0.5, 1.0), "normal sample is finite");
+    expect_true(APPMotionComponentsAreFinite(DBL_MAX, -DBL_MAX, DBL_MIN), "finite boundaries are accepted");
+
+    expect_false(APPMotionComponentsAreFinite(NAN, 0.0, 0.0), "NaN x is rejected");
+    expect_false(APPMotionComponentsAreFinite(0.0, NAN, 0.0), "NaN y is rejected");
+    expect_false(APPMotionComponentsAreFinite(0.0, 0.0, NAN), "NaN z is rejected");
+    expect_false(APPMotionComponentsAreFinite(INFINITY, 0.0, 0.0), "positive infinity is rejected");
+    expect_false(APPMotionComponentsAreFinite(0.0, -INFINITY, 0.0), "negative infinity is rejected");
+
+    if (failure_count != 0) {
+        return 1;
+    }
+
+    puts("APPMotionValidation behavioral tests passed");
+    return 0;
+}

--- a/docs/plans/2026-06-16-executable-motion-validation-tests.md
+++ b/docs/plans/2026-06-16-executable-motion-validation-tests.md
@@ -1,0 +1,26 @@
+# Executable Motion Validation Tests
+
+status: completed
+
+## Goal
+
+Replace static-only confidence in accelerometer component validation with
+executable tests of the same finite-sample predicate used by the app.
+
+## Implementation
+
+- Move the three-component finite check into portable C source compiled by the
+  Maze application target.
+- Keep CoreMotion callback ownership and main-thread gameplay handoff unchanged.
+- Compile and run a repository-owned C harness through every Make gate before
+  static contracts and the optional Xcode build.
+- Treat warnings as errors so the portable test boundary remains strict.
+
+## Verification
+
+- Repository and external-directory `make check` passed with executable C
+  behavior even when Xcode was unavailable.
+- The harness accepts zero, ordinary, and finite boundary samples while
+  rejecting NaN and positive or negative infinity in every component.
+- Hostile mutations were rejected for runner invocation, application
+  delegation, component coverage, compiler warnings, and Xcode membership.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -25,6 +25,7 @@ CORRECTED_COLLISION_PLAN = ROOT / "docs/plans/2026-06-10-corrected-collision-bui
 MAIN_THREAD_MOTION_PLAN = ROOT / "docs/plans/2026-06-12-main-thread-motion-handoff.md"
 FINITE_MOTION_PLAN = ROOT / "docs/plans/2026-06-13-nonfinite-motion-sample-guard.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
+MOTION_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-motion-validation-tests.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -96,6 +97,8 @@ def main():
         "Maze/APPAppDelegate.m",
         "Maze/APPViewController.h",
         "Maze/APPViewController.m",
+        "Maze/APPMotionValidation.c",
+        "Maze/APPMotionValidation.h",
         "Maze/main.m",
         "Maze/en.lproj/APPViewController.xib",
         "Maze/en.lproj/InfoPlist.strings",
@@ -124,7 +127,10 @@ def main():
         "docs/plans/2026-06-12-main-thread-motion-handoff.md",
         "docs/plans/2026-06-13-nonfinite-motion-sample-guard.md",
         "docs/plans/2026-06-13-location-independent-make.md",
+        "docs/plans/2026-06-16-executable-motion-validation-tests.md",
         "docs/readme-overview.svg",
+        "Tests/APPMotionValidationTests.c",
+        "scripts/run-motion-validation-tests.sh",
     ]
 
     for relative_path in required_files:
@@ -157,6 +163,9 @@ def main():
     build_script = read("build.sh")
     view_header = read("Maze/APPViewController.h")
     view_controller = read("Maze/APPViewController.m")
+    motion_validation = read("Maze/APPMotionValidation.c")
+    motion_tests = read("Tests/APPMotionValidationTests.c")
+    motion_test_runner = read("scripts/run-motion-validation-tests.sh")
     source = "\n".join(strip_c_line_comments(path.read_text(encoding="utf-8", errors="replace"))
                        for path in sorted((ROOT / "Maze").glob("*.m")))
     readme = read("README.md")
@@ -182,6 +191,7 @@ def main():
     main_thread_motion_plan = MAIN_THREAD_MOTION_PLAN.read_text(encoding="utf-8") if MAIN_THREAD_MOTION_PLAN.exists() else ""
     finite_motion_plan = FINITE_MOTION_PLAN.read_text(encoding="utf-8") if FINITE_MOTION_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
+    motion_test_plan = MOTION_TEST_PLAN.read_text(encoding="utf-8") if MOTION_TEST_PLAN.exists() else ""
 
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
@@ -211,6 +221,11 @@ def main():
     require("CLANG_ENABLE_OBJC_ARC = YES;" in project and "CoreMotion.framework" in project and "QuartzCore.framework" in project,
             "Xcode project must keep ARC and gameplay framework references",
             failures)
+    require(project.count("APPMotionValidation.c in Sources") == 2 and
+            "path = APPMotionValidation.c;" in project and
+            "path = APPMotionValidation.h;" in project,
+            "Xcode project must compile shared motion validation and expose its header",
+            failures)
     for resource in ["pacman.png", "wall.png", "squareWall.png", "exit.png", "ghost.png", "APPViewController.xib"]:
         require(resource in project,
                 f"Xcode project must keep resource reference: {resource}",
@@ -230,13 +245,13 @@ def main():
             failures)
     callback_index = view_controller.find("startAccelerometerUpdatesToQueue:self.queue withHandler:")
     sample_capture_index = view_controller.find("CMAcceleration acceleration = accelerometerData.acceleration;", callback_index)
-    finite_guard = "if (!isfinite(acceleration.x) || !isfinite(acceleration.y) || !isfinite(acceleration.z)) {\n             return;\n         }"
+    finite_guard = "if (!APPMotionComponentsAreFinite(acceleration.x, acceleration.y, acceleration.z)) {\n             return;\n         }"
     finite_guard_index = view_controller.find(finite_guard, sample_capture_index)
     main_dispatch_index = view_controller.find("dispatch_async(dispatch_get_main_queue(), ^{", sample_capture_index)
     strong_capture_index = view_controller.find("APPViewController *strongSelf = weakSelf;", main_dispatch_index)
     sample_assignment_index = view_controller.find("strongSelf.acceleration = acceleration;", main_dispatch_index)
     update_index = view_controller.find("[strongSelf update];", main_dispatch_index)
-    require("#import <math.h>" in view_controller and
+    require("#import \"APPMotionValidation.h\"" in view_controller and
             "__weak APPViewController *weakSelf = self;" in source and
             callback_index != -1 and sample_capture_index != -1 and finite_guard_index != -1 and main_dispatch_index != -1 and
             strong_capture_index != -1 and sample_assignment_index != -1 and update_index != -1 and
@@ -244,6 +259,30 @@ def main():
             "performSelectorOnMainThread" not in source,
             "accelerometer samples must reject non-finite components before main-thread assignment and update",
             failures)
+    require("return isfinite(x) && isfinite(y) && isfinite(z);" in motion_validation,
+            "shared motion validation must reject every non-finite component",
+            failures)
+    for fragment in [
+        "APPMotionComponentsAreFinite(0.0, 0.0, 0.0)",
+        "APPMotionComponentsAreFinite(DBL_MAX, -DBL_MAX, DBL_MIN)",
+        "APPMotionComponentsAreFinite(NAN, 0.0, 0.0)",
+        "APPMotionComponentsAreFinite(0.0, -INFINITY, 0.0)",
+    ]:
+        require(fragment in motion_tests,
+                f"executable motion validation coverage is missing: {fragment}",
+                failures)
+    for fragment in [
+        '"$CC"',
+        '"$ROOT/Maze/APPMotionValidation.c"',
+        '"$ROOT/Tests/APPMotionValidationTests.c"',
+        '"$BUILD_DIR/motion-validation-tests"',
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+    ]:
+        require(fragment in motion_test_runner,
+                f"motion validation test runner is missing: {fragment}",
+                failures)
     require("NSTimeInterval secondsSinceLastDraw = -([self.lastUpdateTime timeIntervalSinceNow]);" in source and
             "secondsSinceLastDraw = MAX(0, MIN(secondsSinceLastDraw, 0.1));" in source,
             "gameplay updates must clamp frame time deltas before integrating accelerometer velocity",
@@ -323,12 +362,24 @@ def main():
             ".gitignore must exclude local config and Xcode build products",
             failures)
     require(".PHONY: build check lint test" in makefile and
+            "CC ?= cc" in makefile and
             "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
             "lint test build: check" in makefile and
-            'check:\n\tpython3 "$(ROOT)/scripts/check-baseline.py"\n\tcd "$(ROOT)" && ./build.sh' in makefile and
+            'CC="$(CC)" "$(ROOT)/scripts/run-motion-validation-tests.sh"' in makefile and
+            'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and
+            'cd "$(ROOT)" && ./build.sh' in makefile and
             "python3 scripts/check-baseline.py" not in makefile and
             "\n\t./build.sh" not in makefile,
             "Makefile must expose location-independent aliases and compile through the check gate when Xcode is available",
+            failures)
+    require("status: completed" in motion_test_plan and
+            "make check" in motion_test_plan and
+            "hostile mutations" in motion_test_plan.lower(),
+            "executable motion validation plan must preserve completed verification evidence",
+            failures)
+    require("docs/plans/2026-06-16-executable-motion-validation-tests.md" in readme and
+            "executable C" in readme,
+            "README must document executable motion validation coverage",
             failures)
     require("make lint" in readme and "make test" in readme and "make build" in readme and "make check" in readme and "build.sh" in readme and "Maze.xcodeproj" in readme,
             "README must document static verification, build script, and project usage",

--- a/scripts/run-motion-validation-tests.sh
+++ b/scripts/run-motion-validation-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CC=${CC:-cc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ios-pacman-motion-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$CC" \
+    -std=c11 \
+    -Wall \
+    -Wextra \
+    -Werror \
+    -I"$ROOT/Maze" \
+    "$ROOT/Maze/APPMotionValidation.c" \
+    "$ROOT/Tests/APPMotionValidationTests.c" \
+    -lm \
+    -o "$BUILD_DIR/motion-validation-tests"
+
+"$BUILD_DIR/motion-validation-tests"


### PR DESCRIPTION
## Summary

Finite accelerometer validation is now executed as portable C behavior using the same predicate called by the CoreMotion callback. Every canonical Make gate runs those tests before static contracts and the optional unsigned simulator build.

## Baseline

The repository previously protected non-finite sensor rejection with static source matching only. The callback could still compile with a semantically incomplete predicate without any executable assertion failing.

## Improvements

The three-component finite check now lives in `APPMotionValidation`, compiled into the Maze application target and a repository-owned C harness. The harness accepts zero, ordinary, and finite boundary samples while rejecting NaN and positive or negative infinity in each component under strict compiler warnings.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- All four aliases through the absolute Makefile path from `/tmp`
- Real C execution with `-std=c11 -Wall -Wextra -Werror`
- Python, build-script, and test-runner syntax checks
- Xcode project source membership, diff integrity, artifact, and secret checks
- Eight hostile mutations rejected across runner invocation, production delegation, component validation, behavioral coverage, compiler strictness, project membership, and runner input
- Local host recorded explicit `xcodebuild` unavailability; hosted simulator compilation is pending

## Risk

CoreMotion callback ownership and main-thread gameplay handoff are unchanged, but the finite predicate moved into a C translation unit. Hosted macOS execution and the simulator application build must pass at this exact head before the behavioral limitation can be cleared.

## Follow-Ups

Record exact-head hosted results once the canonical checks reach a terminal state. Accelerometer hardware input, alerts, rendering, and full gameplay remain outside this deterministic harness.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)
