### PR TITLE
Pause motion outside the active app lifecycle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Tied accelerometer start and stop to the active app lifecycle and rejected
+  stale queued motion across pause/resume boundaries.
+
 ## 2026-06-16
 
 - Added executable C tests for finite accelerometer samples using the same

--- a/Maze/APPAppDelegate.m
+++ b/Maze/APPAppDelegate.m
@@ -20,6 +20,7 @@
 
 - (void)applicationWillResignActive:(UIApplication *)application
 {
+    [self.viewController stopMotionUpdates];
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
 }
@@ -37,6 +38,7 @@
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
+    [self.viewController startMotionUpdates];
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 }
 

--- a/Maze/APPViewController.h
+++ b/Maze/APPViewController.h
@@ -30,4 +30,7 @@
 @property (assign, nonatomic) BOOL collisionAlertVisible;
 @property (assign, nonatomic) BOOL gameCompleted;
 
+- (void)startMotionUpdates;
+- (void)stopMotionUpdates;
+
 @end

--- a/Maze/APPViewController.m
+++ b/Maze/APPViewController.m
@@ -8,6 +8,8 @@
 
 @interface APPViewController ()
 
+@property (assign, nonatomic) NSUInteger motionUpdateGeneration;
+
 @end
 
 @implementation APPViewController
@@ -59,6 +61,17 @@
     
     self.motionManager.accelerometerUpdateInterval = kUpdateInterval;
 
+}
+
+- (void)startMotionUpdates {
+    if (self.gameCompleted || [self.motionManager isAccelerometerActive]) {
+        return;
+    }
+
+    self.motionUpdateGeneration += 1;
+    NSUInteger motionGeneration = self.motionUpdateGeneration;
+    self.lastUpdateTime = [NSDate date];
+
     __weak APPViewController *weakSelf = self;
     [self.motionManager startAccelerometerUpdatesToQueue:self.queue withHandler:
      ^(CMAccelerometerData *accelerometerData, NSError *error) {
@@ -74,11 +87,19 @@
              if (strongSelf == nil) {
                  return;
              }
+             if (strongSelf.motionUpdateGeneration != motionGeneration
+                 || ![strongSelf.motionManager isAccelerometerActive]) {
+                 return;
+             }
              strongSelf.acceleration = acceleration;
              [strongSelf update];
          });
      }];
+}
 
+- (void)stopMotionUpdates {
+    self.motionUpdateGeneration += 1;
+    [self.motionManager stopAccelerometerUpdates];
 }
 
 - (void)movePacman {
@@ -133,7 +154,7 @@
         self.gameCompleted = YES;
         self.pacmanXVelocity = 0;
         self.pacmanYVelocity = 0;
-        [self.motionManager stopAccelerometerUpdates];
+        [self stopMotionUpdates];
         self.collisionAlertVisible = YES;
         
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Congratulations"
@@ -261,7 +282,7 @@
 
 - (void)dealloc
 {
-    [self.motionManager stopAccelerometerUpdates];
+    [self stopMotionUpdates];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Review changes touching network requests, sockets, or service endpoints; examples from the scan include Maze/Maze-Info.plist.
 - Review changes touching file, media, JSON, XML, CSV, OCR, or data parsing; examples from the scan include Maze/APPViewController.m, Maze/Maze-Info.plist.
 - Resource changes should keep image files, XIB outlets, screenshot, and Xcode project references aligned.
-- Accelerometer callbacks should not strongly retain the controller; non-finite motion samples should be rejected and valid updates should remain bounded to the live game screen.
+- Accelerometer callbacks should not strongly retain the controller. Non-finite
+  motion samples should be rejected, updates should follow the active app lifecycle,
+  and stale queued motion should not cross pause/resume boundaries.
 - `build.sh` should stay valid for `/bin/sh` because CI and local shells may not invoke bash.
 
 ## Maintenance Notes
@@ -118,6 +120,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   value guardrail.
 - See `docs/plans/2026-06-16-executable-motion-validation-tests.md` for the
   shared finite-sample predicate and executable C behavioral gate.
+- See `docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md` for active
+  app lifecycle ownership and stale queued motion rejection.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions static
   baseline.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,11 @@ Helpful reports include:
 - This should remain a local game sample. Treat new accounts, analytics, persistence, upload, networking, or telemetry as security-sensitive until the data flow and user value are documented.
 - `build.sh` is part of the supported build surface; keep it POSIX-shell compatible and review any changes to simulator destination, scheme, or signing behavior.
 - `build.sh` should skip cleanly on hosts without Xcode instead of failing after partial setup.
-- Accelerometer callbacks should avoid retaining the gameplay controller after the screen is gone; non-finite motion samples must be rejected before valid samples are assigned and integrated together on the main thread, and updates must remain tied to the live controller lifecycle.
+- Accelerometer callbacks should avoid retaining the gameplay controller after
+  the screen is gone; non-finite motion samples must be rejected before valid samples
+  are assigned and integrated on the main thread. Updates must follow the
+  active app lifecycle, and generation checks must reject stale queued motion
+  across pause/resume boundaries.
 - Collision alerts should stay gated while visible so repeated collision frames do not stack duplicate modal prompts, failure collision handling should apply a velocity reset before prompting, previous position initialization should keep wall-collision rollback aligned with the starting point, win completion should stop future movement updates after the exit alert, alert pause behavior should stop movement updates behind those prompts, and alert dismissal should reset the frame clock before movement resumes.
 - Boundary and wall constraints should be resolved before exit and ghost outcomes, which must use the corrected candidate frame and stop after a terminal win.
 - `make check` runs a static baseline that guards image/XIB references, plist/scheme metadata, Xcode project wiring, shell syntax, source inventory, and local-only gameplay behavior when Xcode is unavailable.

--- a/VISION.md
+++ b/VISION.md
@@ -18,7 +18,8 @@ Priority:
 - Preserve the maze gameplay and asset references
 - Keep the screenshot and README aligned with app behavior
 - Maintain the build script and Xcode project structure
-- Keep accelerometer updates bounded to the live controller lifecycle
+- Keep accelerometer updates bounded to the active app lifecycle
+- Reject stale queued motion across pause/resume boundaries
 - Assign and integrate each accelerometer sample together on the main thread
 - Reject non-finite motion samples before they enter gameplay state
 - Gate collision alerts so repeated frames do not stack modal alerts
@@ -68,7 +69,8 @@ velocity reset behavior, previous position initialization, win completion update
 guarding, and alert pause behavior, with local-only gameplay and alert frame
 clock reset behavior, with no debug logging, network, analytics, upload, or
 persistence behavior.
-It also verifies that motion callbacks avoid strongly retaining the controller.
+It also verifies that motion callbacks avoid strongly retaining the controller,
+follow the active app lifecycle, and reject stale queued motion after a pause.
 GitHub Actions runs that static baseline with Python 3.12.
 
 ## What We Will Not Merge (For Now)

--- a/docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md
+++ b/docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md
@@ -1,0 +1,121 @@
+---
+title: Active-App Motion Lifecycle
+type: fix
+date: 2026-06-17
+---
+
+# Active-App Motion Lifecycle
+
+## Summary
+
+Tie accelerometer delivery to the app's active lifecycle instead of starting it
+once in `viewDidLoad` and stopping only during controller teardown. Invalidate
+queued samples across each stop/restart boundary so inactive or stale motion
+cannot update gameplay.
+
+## Problem Frame
+
+The root gameplay controller remains alive when the app loses focus or enters
+the background, so `dealloc` does not stop CoreMotion. Sensor and operation-queue
+work can continue while gameplay is inactive, and a callback queued before the
+pause can arrive after a later resume.
+
+Apple documents `UIApplicationWillResignActiveNotification` as the loss-of-focus
+boundary and `applicationDidBecomeActive:` as the point where active work may
+resume. `CMMotionManager` remains active between its start and stop calls.
+
+## Requirements
+
+- R1. Start accelerometer updates when the application becomes active, not from
+  one-time view loading.
+- R2. Stop accelerometer updates when the application will resign active and
+  during controller teardown or terminal win completion.
+- R3. Make start and stop idempotent so repeated lifecycle callbacks do not
+  duplicate handlers or corrupt state.
+- R4. Invalidate queued callbacks with a generation token across every stop and
+  restart boundary before assigning acceleration or updating gameplay.
+- R5. Reset the frame clock when motion resumes so inactive time cannot produce
+  a stale integration interval.
+- R6. Preserve finite-sample validation, weak capture, main-thread handoff,
+  collision behavior, velocity policy, assets, and project metadata.
+- R7. Add mutation-sensitive static contracts and synchronized lifecycle
+  guidance, with the hosted macOS build as the Objective-C compile boundary.
+
+## Key Technical Decisions
+
+- **App delegate drives active-state ownership:** the existing pre-scene app
+  delegate already receives active/inactive callbacks and owns the root
+  controller.
+- **Controller owns CoreMotion implementation:** public lifecycle methods hide
+  the handler, queue, clock, and generation details from the app delegate.
+- **Generation guards queued work:** a captured generation must still match on
+  the main queue, preventing pre-stop samples from crossing a pause or resume.
+- **Terminal wins remain terminal:** active-state callbacks must not restart
+  motion after the game has completed.
+
+## Implementation Units
+
+### U1. Encapsulate motion start and stop
+
+- **Goal:** Move handler registration into idempotent controller lifecycle
+  methods and preserve finite, weak, main-thread sample handling.
+- **Files:** `Maze/APPViewController.h`, `Maze/APPViewController.m`
+- **Verification:** Static ordering checks cover generation capture, stale
+  rejection, clock reset, duplicate-start guard, stop invalidation, win stop,
+  and teardown stop.
+- **Covers:** R1, R2, R3, R4, R5, R6.
+
+### U2. Connect application lifecycle callbacks
+
+- **Goal:** Stop before the app loses active status and restart after it becomes
+  active.
+- **Files:** `Maze/APPAppDelegate.m`
+- **Patterns:** Reuse the existing root-controller property without adding
+  notification observers or scene APIs to this legacy app.
+- **Covers:** R1, R2, R3.
+
+### U3. Lock verification and guidance
+
+- **Goal:** Extend the canonical checker and maintenance documentation with the
+  active-app motion lifecycle contract.
+- **Files:** `scripts/check-baseline.py`, `README.md`, `SECURITY.md`, `VISION.md`,
+  `CHANGES.md`
+- **Verification:** Root and external Make gates plus isolated mutations of app
+  lifecycle wiring, generation invalidation, restart guards, docs, and checker
+  enforcement.
+- **Covers:** R7.
+
+## Risks And Mitigations
+
+- A stop can race a previously queued main-thread block; generation comparison
+  rejects that block even if motion restarts before it executes.
+- Repeated active callbacks can otherwise register duplicate handlers; check
+  `isAccelerometerActive` before starting.
+- Linux cannot compile UIKit/CoreMotion Objective-C; keep source contracts local
+  and require both hosted macOS event paths on the exact head.
+
+## Scope Boundaries
+
+- Do not change acceleration math, velocity reset semantics, collisions, alerts,
+  ghost animation, win behavior, assets, XIB wiring, dependencies, or project
+  settings.
+- Do not migrate the legacy app to scenes, notifications, or a new motion
+  abstraction.
+- Do not add background motion execution or permissions.
+
+## Verification
+
+- Run the executable C motion-validation harness.
+- Run `make lint`, `make test`, `make build`, and `make check` from the checkout.
+- Run the absolute-path Make gate from an external directory.
+- Compile the Python checker, validate `build.sh`, and run `git diff --check`.
+- Reject isolated mutations covering app lifecycle calls, duplicate-start
+  protection, generation invalidation, stale callback rejection, clock reset,
+  documentation, and checker enforcement.
+- Audit intended files for generated artifacts and credential-shaped content.
+
+## References
+
+- [UIApplicationWillResignActiveNotification](https://developer.apple.com/documentation/uikit/uiapplication/willresignactivenotification?language=objc)
+- [UIApplicationDelegate applicationDidBecomeActive:](https://developer.apple.com/documentation/uikit/uiapplicationdelegate)
+- [CMMotionManager stopAccelerometerUpdates](https://developer.apple.com/documentation/coremotion/cmmotionmanager/stopaccelerometerupdates%28%29)

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -26,6 +26,7 @@ MAIN_THREAD_MOTION_PLAN = ROOT / "docs/plans/2026-06-12-main-thread-motion-hando
 FINITE_MOTION_PLAN = ROOT / "docs/plans/2026-06-13-nonfinite-motion-sample-guard.md"
 LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independent-make.md"
 MOTION_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-motion-validation-tests.md"
+ACTIVE_MOTION_PLAN = ROOT / "docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -128,6 +129,7 @@ def main():
         "docs/plans/2026-06-13-nonfinite-motion-sample-guard.md",
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-16-executable-motion-validation-tests.md",
+        "docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md",
         "docs/readme-overview.svg",
         "Tests/APPMotionValidationTests.c",
         "scripts/run-motion-validation-tests.sh",
@@ -161,6 +163,7 @@ def main():
     project = read("Maze.xcodeproj/project.pbxproj")
     xib = read("Maze/en.lproj/APPViewController.xib")
     build_script = read("build.sh")
+    app_delegate = read("Maze/APPAppDelegate.m")
     view_header = read("Maze/APPViewController.h")
     view_controller = read("Maze/APPViewController.m")
     motion_validation = read("Maze/APPMotionValidation.c")
@@ -192,6 +195,7 @@ def main():
     finite_motion_plan = FINITE_MOTION_PLAN.read_text(encoding="utf-8") if FINITE_MOTION_PLAN.exists() else ""
     location_independent_make_plan = LOCATION_INDEPENDENT_MAKE_PLAN.read_text(encoding="utf-8") if LOCATION_INDEPENDENT_MAKE_PLAN.exists() else ""
     motion_test_plan = MOTION_TEST_PLAN.read_text(encoding="utf-8") if MOTION_TEST_PLAN.exists() else ""
+    active_motion_plan = ACTIVE_MOTION_PLAN.read_text(encoding="utf-8") if ACTIVE_MOTION_PLAN.exists() else ""
 
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
@@ -243,21 +247,66 @@ def main():
     require("error != nil || accelerometerData == nil" in source and "- (void)dealloc" in source,
             "Objective-C source must ignore unavailable motion samples and stop updates during teardown",
             failures)
+    start_method_index = view_controller.find("- (void)startMotionUpdates")
+    stop_method_index = view_controller.find("- (void)stopMotionUpdates")
     callback_index = view_controller.find("startAccelerometerUpdatesToQueue:self.queue withHandler:")
+    duplicate_start_guard_index = view_controller.find(
+        "if (self.gameCompleted || [self.motionManager isAccelerometerActive]) {",
+        start_method_index,
+    )
+    generation_increment_index = view_controller.find(
+        "self.motionUpdateGeneration += 1;", duplicate_start_guard_index
+    )
+    generation_capture_index = view_controller.find(
+        "NSUInteger motionGeneration = self.motionUpdateGeneration;",
+        generation_increment_index,
+    )
+    resume_clock_index = view_controller.find(
+        "self.lastUpdateTime = [NSDate date];", generation_capture_index
+    )
     sample_capture_index = view_controller.find("CMAcceleration acceleration = accelerometerData.acceleration;", callback_index)
     finite_guard = "if (!APPMotionComponentsAreFinite(acceleration.x, acceleration.y, acceleration.z)) {\n             return;\n         }"
     finite_guard_index = view_controller.find(finite_guard, sample_capture_index)
     main_dispatch_index = view_controller.find("dispatch_async(dispatch_get_main_queue(), ^{", sample_capture_index)
     strong_capture_index = view_controller.find("APPViewController *strongSelf = weakSelf;", main_dispatch_index)
+    stale_generation_index = view_controller.find(
+        "if (strongSelf.motionUpdateGeneration != motionGeneration", strong_capture_index
+    )
     sample_assignment_index = view_controller.find("strongSelf.acceleration = acceleration;", main_dispatch_index)
     update_index = view_controller.find("[strongSelf update];", main_dispatch_index)
+    view_did_load = view_controller[view_controller.find("- (void)viewDidLoad"):start_method_index]
+    stop_method = view_controller[stop_method_index:view_controller.find("- (void)movePacman", stop_method_index)]
+    require("- (void)startMotionUpdates;" in view_header and
+            "- (void)stopMotionUpdates;" in view_header and
+            "@property (assign, nonatomic) NSUInteger motionUpdateGeneration;" in view_controller and
+            "startAccelerometerUpdatesToQueue" not in view_did_load and
+            start_method_index != -1 and stop_method_index != -1 and
+            duplicate_start_guard_index != -1 and generation_increment_index != -1 and
+            generation_capture_index != -1 and resume_clock_index != -1 and callback_index != -1 and
+            start_method_index < duplicate_start_guard_index < generation_increment_index < generation_capture_index < resume_clock_index < callback_index and
+            "self.motionUpdateGeneration += 1;" in stop_method and
+            "[self.motionManager stopAccelerometerUpdates];" in stop_method,
+            "motion ownership must use idempotent controller start/stop methods with generation invalidation and a fresh resume clock",
+            failures)
     require("#import \"APPMotionValidation.h\"" in view_controller and
             "__weak APPViewController *weakSelf = self;" in source and
             callback_index != -1 and sample_capture_index != -1 and finite_guard_index != -1 and main_dispatch_index != -1 and
-            strong_capture_index != -1 and sample_assignment_index != -1 and update_index != -1 and
-            callback_index < sample_capture_index < finite_guard_index < main_dispatch_index < strong_capture_index < sample_assignment_index < update_index and
+            strong_capture_index != -1 and stale_generation_index != -1 and
+            sample_assignment_index != -1 and update_index != -1 and
+            callback_index < sample_capture_index < finite_guard_index < main_dispatch_index < strong_capture_index < stale_generation_index < sample_assignment_index < update_index and
+            "|| ![strongSelf.motionManager isAccelerometerActive]" in view_controller[stale_generation_index:sample_assignment_index] and
             "performSelectorOnMainThread" not in source,
-            "accelerometer samples must reject non-finite components before main-thread assignment and update",
+            "accelerometer samples must reject non-finite or stale generations before main-thread assignment and update",
+            failures)
+    will_resign_index = app_delegate.find("- (void)applicationWillResignActive:")
+    did_enter_background_index = app_delegate.find("- (void)applicationDidEnterBackground:")
+    did_become_active_index = app_delegate.find("- (void)applicationDidBecomeActive:")
+    will_terminate_index = app_delegate.find("- (void)applicationWillTerminate:")
+    require(will_resign_index != -1 and did_enter_background_index != -1 and
+            did_become_active_index != -1 and will_terminate_index != -1 and
+            "[self.viewController stopMotionUpdates];" in app_delegate[will_resign_index:did_enter_background_index] and
+            "[self.viewController startMotionUpdates];" in app_delegate[did_become_active_index:will_terminate_index],
+            "application active-state callbacks must stop and restart controller-owned motion updates",
             failures)
     require("return isfinite(x) && isfinite(y) && isfinite(z);" in motion_validation,
             "shared motion validation must reject every non-finite component",
@@ -306,7 +355,7 @@ def main():
     win_completed_index = view_controller.find("self.gameCompleted = YES;", exit_collision_index)
     win_x_velocity_reset_index = view_controller.find("self.pacmanXVelocity = 0;", exit_collision_index)
     win_y_velocity_reset_index = view_controller.find("self.pacmanYVelocity = 0;", exit_collision_index)
-    win_motion_stop_index = view_controller.find("[self.motionManager stopAccelerometerUpdates];", exit_collision_index)
+    win_motion_stop_index = view_controller.find("[self stopMotionUpdates];", exit_collision_index)
     win_alert_index = view_controller.find('UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Congratulations"', exit_collision_index)
     require(exit_collision_index != -1 and win_completed_index != -1 and
             win_x_velocity_reset_index != -1 and win_y_velocity_reset_index != -1 and
@@ -406,6 +455,9 @@ def main():
     require("non-finite motion" in readme.lower(),
             "README must document invalid sensor sample rejection",
             failures)
+    require("active app lifecycle" in readme.lower() and "stale queued motion" in readme.lower(),
+            "README must document active-app ownership and stale queued motion rejection",
+            failures)
     require("scripts/check-baseline.py" in vision and "make lint" in vision and "make test" in vision and "make build" in vision and "asset" in vision.lower() and
             "time delta" in vision.lower() and "collision alert" in vision.lower() and "alert pause" in vision.lower(),
             "VISION must describe the current static Objective-C game baseline",
@@ -428,6 +480,9 @@ def main():
     require("non-finite motion" in vision.lower(),
             "VISION must describe invalid sensor sample rejection",
             failures)
+    require("active app lifecycle" in vision.lower() and "stale queued motion" in vision.lower(),
+            "VISION must describe active-app ownership and stale queued motion rejection",
+            failures)
     require("build.sh" in security and "make check" in security and "collision alert" in security.lower() and
             "alert pause" in security.lower() and "frame clock" in security.lower(),
             "SECURITY must document build script and static baseline guardrails",
@@ -446,6 +501,9 @@ def main():
             failures)
     require("non-finite motion" in security.lower(),
             "SECURITY must document invalid sensor sample guardrails",
+            failures)
+    require("active app lifecycle" in security.lower() and "stale queued motion" in security.lower(),
+            "SECURITY must document active-app ownership and stale queued motion guardrails",
             failures)
     require("/bin/sh" in changes and "without Xcode" in changes and "accelerometer" in changes and
             "weak" in changes.lower() and "time delta" in changes.lower() and
@@ -466,6 +524,9 @@ def main():
             failures)
     require("non-finite motion" in changes.lower(),
             "CHANGES must record invalid sensor sample rejection",
+            failures)
+    require("active app lifecycle" in changes.lower() and "stale queued motion" in changes.lower(),
+            "CHANGES must record active-app ownership and stale queued motion rejection",
             failures)
     require("GitHub Actions" in changes,
             "CHANGES must record hosted baseline coverage",
@@ -515,6 +576,13 @@ def main():
             "All four Make gates" in finite_motion_plan and
             "hostile mutations" in finite_motion_plan.lower(),
             "non-finite motion sample plan must record completed status and verification",
+            failures)
+    require("title: Active-App Motion Lifecycle" in active_motion_plan and
+            "type: fix" in active_motion_plan and
+            "date: 2026-06-17" in active_motion_plan and
+            "R1." in active_motion_plan and "R7." in active_motion_plan and
+            not re.search(r"(?mi)^status:\s*", active_motion_plan),
+            "active-app motion lifecycle plan must preserve modern metadata and requirements without legacy status fields",
             failures)
     location_make_statuses = re.findall(
         r"^status: .+$", location_independent_make_plan, flags=re.MULTILINE


### PR DESCRIPTION
## Summary

Pause accelerometer-driven motion whenever the application leaves its active
lifecycle state, then restart cleanly when the application becomes active again.

## Baseline

Accelerometer delivery and queued CoreMotion samples could continue across
inactive lifecycle boundaries. Resuming without resetting the frame clock could
also apply stale timing to the first active frame.

## Improvements

- Start and stop accelerometer delivery with `UIApplication` active-state callbacks.
- Invalidate queued CoreMotion samples across every stop and restart boundary.
- Reset the frame clock on resume while preserving terminal-win shutdown.
- Enforce the lifecycle contract in the canonical static gate and maintenance documentation.

## Validation

- `make lint`, `make test`, `make build`, and `make check` from the checkout
- All four Make gates through the absolute Makefile path from `/tmp`
- Executable C motion-validation harness
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh`
- `git diff --check`
- Eight isolated hostile mutations rejected

`xcodebuild` is unavailable on the Linux host; the existing bounded macOS
workflow remains the Objective-C and iOS compilation boundary.

## Risk

The primary risk is failing to restart motion after a legitimate active-state
transition or processing a stale queued sample after resume. The lifecycle gate,
motion harness, hostile mutations, and exact-head macOS checks cover these paths.

## Follow-Ups

This branch is based on PR #7, which adds executable motion validation tests.
Verify both canonical GitHub Actions events remain green at the exact head before
merge and preserve that dependency ordering.
