### PR TITLE
fix: protect make root resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build check lint test
 
 CC ?= cc
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -429,7 +429,7 @@ def main():
             failures)
     require(".PHONY: build check lint test" in makefile and
             "CC ?= cc" in makefile and
-            "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
+            "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))" in makefile and
             "lint test build: check" in makefile and
             'CC="$(CC)" "$(ROOT)/scripts/run-motion-validation-tests.sh"' in makefile and
             'python3 "$(ROOT)/scripts/check-baseline.py"' in makefile and


### PR DESCRIPTION
## Summary

Historical closed pull request: fix: protect make root resolution

### Original Description

### Summary

Canonical motion validation can no longer be redirected outside the checkout by an inherited or command-line `ROOT` value. The Makefile now treats its own location as authoritative, and the baseline checker rejects any regression to an overridable root assignment.

## Test Plan

- `make lint`, `make test`, `make build`, and `make check` from the repository with a hostile `ROOT`
- all four aliases through the absolute Makefile path from an external directory with the same hostile `ROOT`
- compiled `APPMotionValidation` behavior harness passed in every alias invocation
- isolated downgrade mutation rejected by `scripts/check-baseline.py`
- in-memory Python compilation, shell syntax, `git diff --check`, and `git fsck --full`
- checksum-verified Gitleaks 8.30.1 history and current-tree scans

Local Linux validation reports the existing Xcode limitation; hosted macOS remains authoritative for the iOS project build.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

## Baseline

The original pull request predates the fleet-standard description contract; repository history and code remain unchanged by this metadata update.

## Improvements

The implementation intent remains the motion validation, gameplay lifecycle, resource integrity, build, CI, or documentation change described by the title and preserved original description.

## Validation

No code was rerun solely for this metadata normalization. Fresh exact-master local and hosted evidence is recorded separately in the engineering-bar tracker.

## Risk

This description-only normalization changes no source, commit, branch, credential, project setting, motion data, resource, or runtime behavior.

## Follow-Ups

No follow-up is required for this metadata-only update; live accelerometer and gameplay interaction remain bounded by the exact-head evidence.
