### PR TITLE
Pause motion during collision alerts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@
 - Accelerometer callbacks should not strongly retain the controller; each non-finite or overflow-prone sample should be rejected before valid samples are assigned and integrated together on the main thread, and motion updates should remain bounded to the live game screen.
 - Keep the accelerometer availability guard ahead of motion generation, frame
   clock, capture, and handler startup side effects.
+- Keep collision alerts as a sensor lifecycle boundary: visible alerts reject
+  motion startup, ghost collisions stop the active stream, and dismissal clears
+  the guard before restarting non-terminal gameplay.
 - `build.sh` should stay valid for `/bin/sh` because CI and local shells may not invoke bash, and Xcode DerivedData should stay temp-scoped unless explicitly overridden.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,48 @@
 # Changes
 
+## 2026-06-25 05:18 - P2 - Pause motion delivery during collision alerts
+
+### Summary
+Stopped Core Motion delivery while a ghost collision alert owns the game screen
+and resumed only after dismissal clears the alert guard.
+
+### Work completed
+- Added collision-alert visibility to the motion startup guard.
+- Invalidated and stopped the active accelerometer stream before failure alerts.
+- Restarted non-terminal motion after alert dismissal and clock refresh.
+
+### Threads
+- Started: none — work completed directly in the current repository.
+- Continued: none.
+- Stopped: none.
+
+### Files changed
+- `Maze/APPViewController.m` — enforced alert-scoped motion ownership.
+- `scripts/check-baseline.py` — added ordered pause/resume source contracts.
+- Documentation and plan files — recorded behavior, evidence, and boundaries.
+
+### Validation
+- `python3 scripts/check-baseline.py` — failed in three expected lifecycle
+  contracts before implementation and passed afterward.
+- `/usr/bin/make check` — passed the executable C harness, static baseline, and
+  conditional build gate; Xcode was unavailable locally.
+- Three isolated hostile mutations removing the guard, stop, or restart were
+  rejected by their focused contracts.
+- `python3 -m py_compile scripts/check-baseline.py`, shell syntax checks, and
+  `git diff --check` — passed.
+- Hosted Xcode and CodeQL checks — pending PR verification.
+
+### Bugs / findings
+- P2: modal collision alerts paused gameplay state updates but left the 60 Hz
+  accelerometer stream and callback dispatch active behind the prompt.
+
+### Blockers
+- `xcodebuild` is unavailable locally; hosted macOS CI remains authoritative for
+  Objective-C, UIKit, and Core Motion compilation.
+
+### Next action
+- Open a PR and complete Codex plus hosted review before merge.
+
 ## 2026-06-18
 
 - Kept Xcode build artifacts temp-scoped through `build.sh`, stopped motion on

--- a/Maze/APPViewController.m
+++ b/Maze/APPViewController.m
@@ -65,6 +65,7 @@
 
 - (void)startMotionUpdates {
     if (self.gameCompleted
+        || self.collisionAlertVisible
         || ![self.motionManager isAccelerometerAvailable]
         || [self.motionManager isAccelerometerActive]) {
         return;
@@ -187,6 +188,7 @@
         self.pacmanXVelocity = 0;
         self.pacmanYVelocity = 0;
         self.collisionAlertVisible = YES;
+        [self stopMotionUpdates];
         
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Oops!"
                                                   message:@"Mission Failed!"
@@ -280,6 +282,7 @@
 {
     self.collisionAlertVisible = NO;
     self.lastUpdateTime = [NSDate date];
+    [self startMotionUpdates];
 }
 
 - (void)dealloc

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   or overflow-prone motion samples should be rejected, updates should follow the
   active app lifecycle, and stale queued motion should not cross pause/resume
   boundaries.
+- Ghost collision alerts stop accelerometer delivery while the modal prompt is
+  visible. Dismissal clears the alert guard, refreshes the frame clock, and then
+  resumes motion; terminal win alerts remain stopped.
 - `build.sh` should stay valid for `/bin/sh` because CI and local shells may not invoke bash.
 
 ## Maintenance Notes
@@ -135,6 +138,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   shared finite-sample predicate and executable C behavioral gate.
 - See `docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md` for active
   app lifecycle ownership and stale queued motion rejection.
+- See `docs/plans/2026-06-25-pause-motion-during-alerts.md` for collision-alert
+  sensor suspension and guarded dismissal resume behavior.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions static
   baseline.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,7 +38,7 @@ Helpful reports include:
   stale queued motion across pause/resume boundaries.
 - The accelerometer availability guard must reject unsupported hardware before
   motion startup mutates generation or timing state.
-- Collision alerts should stay gated while visible so repeated collision frames do not stack duplicate modal prompts, failure collision handling should apply a velocity reset before prompting, previous position initialization should keep wall-collision rollback aligned with the starting point, win completion should stop future movement updates after the exit alert, alert pause behavior should stop movement updates behind those prompts, and alert dismissal should reset the frame clock before movement resumes.
+- Collision alerts should stay gated while visible so repeated collision frames do not stack duplicate modal prompts. Failure collision handling should apply a velocity reset and stop accelerometer delivery before prompting; motion startup must reject visible alerts, and dismissal should clear the alert guard and reset the frame clock before resuming. This alert pause keeps both gameplay and sensor work suspended. Previous position initialization should keep wall-collision rollback aligned with the starting point, while win completion must keep motion stopped after the exit alert.
 - Boundary and wall constraints should be resolved before exit and ghost outcomes, which must use the corrected candidate frame and stop after a terminal win.
 - `make check` runs a static baseline that guards image/XIB references, plist/scheme metadata, Xcode project wiring, shell syntax, source inventory, and local-only gameplay behavior when Xcode is unavailable.
 - GitHub Actions runs the same static baseline with Python 3.12 for pushes and

--- a/VISION.md
+++ b/VISION.md
@@ -19,6 +19,8 @@ Priority:
 - Keep the screenshot and README aligned with app behavior
 - Maintain the build script and Xcode project structure
 - Keep accelerometer updates bounded to the active app lifecycle
+- Stop accelerometer delivery while collision alerts own the game screen, and
+  resume only after dismissal clears the alert guard
 - Keep the accelerometer availability guard ahead of motion startup state
 - Reject stale queued motion across pause/resume boundaries
 - Assign and integrate each accelerometer sample together on the main thread

--- a/docs/plans/2026-06-25-pause-motion-during-alerts.md
+++ b/docs/plans/2026-06-25-pause-motion-during-alerts.md
@@ -1,0 +1,49 @@
+# Pause Motion During Collision Alerts
+
+status: completed
+
+## Context
+
+`update` returned while a collision alert was visible, but the accelerometer
+stream continued producing callbacks. A ghost collision therefore consumed
+sensor and queue work behind a modal prompt, and app activation could restart
+motion before that prompt was dismissed.
+
+Apple's Core Motion guidance says to call `stopAccelerometerUpdates` when motion
+data is no longer needed. The existing alert delegate provides the matching
+post-dismissal boundary for a guarded restart.
+
+## Design
+
+- Add `collisionAlertVisible` to `startMotionUpdates` rejection conditions.
+- Mark the ghost alert visible, then call `stopMotionUpdates` before presenting
+  it so generation invalidation rejects already queued callbacks.
+- On dismissal, clear visibility, refresh the frame clock, and call
+  `startMotionUpdates`; its completed-game and capability guards remain the
+  authority for whether motion can resume.
+
+## Test First
+
+The static baseline was extended before source implementation. It failed for
+the missing startup guard, missing failure-path stop, and missing dismissal
+restart.
+
+## Verification
+
+- `python3 scripts/check-baseline.py`
+- `/usr/bin/make check`
+- Isolated hostile mutations removing the alert guard, stop, or restart
+- `git diff --check`
+- Local `xcodebuild` is unavailable; hosted macOS CI is authoritative.
+
+## Scope Boundaries
+
+- Motion math, finite-sample validation, collision geometry, assets, XIB
+  wiring, deployment target, signing, and terminal win behavior are unchanged.
+- `UIAlertView` remains for compatibility with the legacy sample; modernizing
+  modal presentation is outside this fix.
+
+## References
+
+- https://developer.apple.com/documentation/coremotion/cmmotionmanager
+- https://developer.apple.com/documentation/uikit/uialertviewdelegate

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -28,6 +28,7 @@ LOCATION_INDEPENDENT_MAKE_PLAN = ROOT / "docs/plans/2026-06-13-location-independ
 MOTION_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-motion-validation-tests.md"
 ACTIVE_MOTION_PLAN = ROOT / "docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md"
 ACCELEROMETER_AVAILABILITY_PLAN = ROOT / "docs/plans/2026-06-18-accelerometer-availability-guard.md"
+ALERT_MOTION_PLAN = ROOT / "docs/plans/2026-06-25-pause-motion-during-alerts.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -131,6 +132,7 @@ def main():
         "docs/plans/2026-06-13-location-independent-make.md",
         "docs/plans/2026-06-16-executable-motion-validation-tests.md",
         "docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md",
+        "docs/plans/2026-06-25-pause-motion-during-alerts.md",
         "docs/readme-overview.svg",
         "Tests/APPMotionValidationTests.c",
         "scripts/run-motion-validation-tests.sh",
@@ -199,6 +201,7 @@ def main():
     motion_test_plan = MOTION_TEST_PLAN.read_text(encoding="utf-8") if MOTION_TEST_PLAN.exists() else ""
     active_motion_plan = ACTIVE_MOTION_PLAN.read_text(encoding="utf-8") if ACTIVE_MOTION_PLAN.exists() else ""
     accelerometer_availability_plan = ACCELEROMETER_AVAILABILITY_PLAN.read_text(encoding="utf-8") if ACCELEROMETER_AVAILABILITY_PLAN.exists() else ""
+    alert_motion_plan = ALERT_MOTION_PLAN.read_text(encoding="utf-8") if ALERT_MOTION_PLAN.exists() else ""
 
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
@@ -258,7 +261,7 @@ def main():
     stop_method_index = view_controller.find("- (void)stopMotionUpdates")
     callback_index = view_controller.find("startAccelerometerUpdatesToQueue:self.queue withHandler:")
     duplicate_start_guard_index = view_controller.find(
-        "if (self.gameCompleted\n        || ![self.motionManager isAccelerometerAvailable]\n        || [self.motionManager isAccelerometerActive]) {",
+        "if (self.gameCompleted\n        || self.collisionAlertVisible\n        || ![self.motionManager isAccelerometerAvailable]\n        || [self.motionManager isAccelerometerActive]) {",
         start_method_index,
     )
     availability_guard_index = view_controller.find(
@@ -384,18 +387,26 @@ def main():
     failure_position_reset_index = view_controller.find("self.currentPoint  = CGPointMake(0, 144);", ghost_collision_index)
     failure_x_velocity_reset_index = view_controller.find("self.pacmanXVelocity = 0;", ghost_collision_index)
     failure_y_velocity_reset_index = view_controller.find("self.pacmanYVelocity = 0;", ghost_collision_index)
+    failure_alert_visible_index = view_controller.find("self.collisionAlertVisible = YES;", ghost_collision_index)
+    failure_motion_stop_index = view_controller.find("[self stopMotionUpdates];", ghost_collision_index)
     failure_alert_index = view_controller.find('UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Oops!"', ghost_collision_index)
     require(ghost_collision_index != -1 and failure_position_reset_index != -1 and
             failure_x_velocity_reset_index != -1 and failure_y_velocity_reset_index != -1 and
+            failure_alert_visible_index != -1 and failure_motion_stop_index != -1 and
             failure_alert_index != -1 and
-            failure_position_reset_index < failure_x_velocity_reset_index < failure_y_velocity_reset_index < failure_alert_index,
-            "failure collision handling must reset position and velocities before showing the alert",
+            failure_position_reset_index < failure_x_velocity_reset_index < failure_y_velocity_reset_index <
+            failure_alert_visible_index < failure_motion_stop_index < failure_alert_index,
+            "failure collision handling must reset movement and stop motion before showing the alert",
             failures)
     alert_dismiss = re.search(r"- \(void\)alertView:\(UIAlertView \*\)alertView didDismissWithButtonIndex:\(NSInteger\)buttonIndex[\s\S]+?\n}", view_controller)
     require(alert_dismiss is not None and
             "self.collisionAlertVisible = NO;" in alert_dismiss.group(0) and
-            "self.lastUpdateTime = [NSDate date];" in alert_dismiss.group(0),
-            "alert dismissal must reset the frame clock before gameplay resumes",
+            "self.lastUpdateTime = [NSDate date];" in alert_dismiss.group(0) and
+            "[self startMotionUpdates];" in alert_dismiss.group(0) and
+            alert_dismiss.group(0).find("self.collisionAlertVisible = NO;") <
+            alert_dismiss.group(0).find("self.lastUpdateTime = [NSDate date];") <
+            alert_dismiss.group(0).find("[self startMotionUpdates];"),
+            "alert dismissal must reset the frame clock and restart motion after clearing the alert guard",
             failures)
     require("- (void)update {\n    if (self.collisionAlertVisible || self.gameCompleted) {\n        return;\n    }" in view_controller,
             "gameplay updates must pause while collision alerts are visible or the game is completed",
@@ -442,6 +453,12 @@ def main():
             "make check" in motion_test_plan and
             "hostile mutations" in motion_test_plan.lower(),
             "executable motion validation plan must preserve completed verification evidence",
+            failures)
+    require("status: completed" in alert_motion_plan and
+            "stopMotionUpdates" in alert_motion_plan and
+            "startMotionUpdates" in alert_motion_plan and
+            "hostile mutations" in alert_motion_plan.lower(),
+            "collision-alert motion plan must record completed pause/resume verification",
             failures)
     require("docs/plans/2026-06-16-executable-motion-validation-tests.md" in readme and
             "executable C" in readme,


### PR DESCRIPTION
## Summary
- stop and invalidate the accelerometer stream before presenting ghost collision alerts
- reject motion startup while a collision alert remains visible
- resume non-terminal motion only after dismissal clears the guard and refreshes the frame clock
- add ordered static contracts, hostile-mutation evidence, and lifecycle documentation

## Verification
- `/usr/bin/make check`
- three isolated hostile mutations removing the alert guard, motion stop, or dismissal restart
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n build.sh scripts/run-motion-validation-tests.sh`
- `git diff --check`

`xcodebuild` is unavailable locally, so hosted macOS CI remains authoritative for Objective-C, UIKit, and Core Motion compilation.

## References
- https://developer.apple.com/documentation/coremotion/cmmotionmanager
- https://developer.apple.com/documentation/uikit/uialertviewdelegate
