### PR TITLE
fix: refresh wall collision geometry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@
 - Keep collision alerts as a sensor lifecycle boundary: visible alerts reject
   motion startup, ghost collisions stop the active stream, and dismissal clears
   the guard before restarting non-terminal gameplay.
+- Refresh wall-collision geometry after each rollback so later walls are checked
+  against the corrected candidate frame rather than stale pre-collision state.
 - `build.sh` should stay valid for `/bin/sh` because CI and local shells may not invoke bash, and Xcode DerivedData should stay temp-scoped unless explicitly overridden.
 - This looks like an Apple platform project or sample. Xcode, Swift, CocoaPods, and deployment target versions may need to match the original project era.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,32 @@
 # Changes
 
+## 2026-06-26 - P2 - Refresh wall collision geometry
+
+### Summary
+Recomputed Pac-Man's candidate frame after each wall rollback so subsequent
+walls are evaluated against corrected geometry instead of the stale incoming
+frame.
+
+### Work completed
+- Preserved the existing rollback axis and damped velocity behavior.
+- Added a portable source contract for post-rollback frame refresh ordering.
+- Synchronized gameplay, security, and maintenance guidance.
+
+### Validation
+- The new contract failed before implementation on the single captured frame.
+- Local and hosted validation evidence is recorded in the completed plan.
+
+### Bugs / findings
+- P2: one update overlapping multiple wall images could apply later collision
+  responses using geometry captured before the first rollback.
+
+### Blockers
+- Local `xcodebuild` is unavailable; hosted macOS CI remains authoritative for
+  Objective-C compilation.
+
+### Next action
+- Merge only after exact-head review and hosted checks pass.
+
 ## 2026-06-25 05:18 - P2 - Pause motion delivery during collision alerts
 
 ### Summary

--- a/Maze/APPViewController.m
+++ b/Maze/APPViewController.m
@@ -248,6 +248,8 @@
                 _currentPoint.y = self.previousPoint.y;
                 self.pacmanYVelocity = -(self.pacmanYVelocity / 2.0);
             }
+
+            frame = [self candidatePacmanFrame];
         
        }
     

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The checked-in project has no external dependency manifest. Use Xcode for full b
 - Open `Maze.xcodeproj` in Xcode, choose the sole shared `Maze` scheme, and run
   it on a compatible simulator or device.
 - Run `./build.sh` when the required platform toolchain is installed. On hosts without Xcode, the script exits cleanly after reporting that the Xcode build was skipped. Xcode DerivedData stays in a temp directory unless `DERIVED_DATA_DIR` is set.
-- This is a local game sample with XIB-wired image assets and CoreMotion movement. The accelerometer availability guard rejects unsupported hardware before motion startup state changes. Non-finite or overflow-prone motion samples are rejected before each valid accelerometer sample is assigned and integrated together on the main thread. Gameplay updates clamp the frame time delta before applying accelerometer velocity, resolve boundary and wall constraints before evaluating the corrected collision frame, stop outcome checks after a win, gate collision alerts while visible, and reset the frame clock after alerts. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
+- This is a local game sample with XIB-wired image assets and CoreMotion movement. The accelerometer availability guard rejects unsupported hardware before motion startup state changes. Non-finite or overflow-prone motion samples are rejected before each valid accelerometer sample is assigned and integrated together on the main thread. Gameplay updates clamp the frame time delta before applying accelerometer velocity, refresh candidate geometry after each wall rollback, resolve boundary and wall constraints before evaluating the corrected outcome frame, stop outcome checks after a win, gate collision alerts while visible, and reset the frame clock after alerts. Do not add accounts, analytics, persistence, upload, or network behavior without a dedicated design and security review.
 
 ## Testing and Verification
 
@@ -77,7 +77,7 @@ The baseline first compiles and runs executable C tests against the same finite
 motion-sample predicate used by the CoreMotion callback. It then runs
 `scripts/check-baseline.py`, validates POSIX shell syntax for `build.sh`, parses
 plist/XIB/scheme XML, checks PNG resources, verifies Xcode project references,
-checks corrected collision ordering and candidate-frame use, accelerometer
+checks corrected collision ordering, per-wall candidate-frame refresh, accelerometer
 lifecycle and main-thread handoff, collision alert gating, failure velocity
 reset behavior, previous position initialization, win completion update guards,
 alert pause behavior, alert frame clock reset behavior, frame time delta
@@ -118,6 +118,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Ghost collision alerts stop accelerometer delivery while the modal prompt is
   visible. Dismissal clears the alert guard, refreshes the frame clock, and then
   resumes motion; terminal win alerts remain stopped.
+- Wall collision rollback refreshes the candidate frame before later walls are
+  evaluated, preventing stale geometry from applying extra collision responses.
 - `build.sh` should stay valid for `/bin/sh` because CI and local shells may not invoke bash.
 
 ## Maintenance Notes
@@ -140,6 +142,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   app lifecycle ownership and stale queued motion rejection.
 - See `docs/plans/2026-06-25-pause-motion-during-alerts.md` for collision-alert
   sensor suspension and guarded dismissal resume behavior.
+- See `docs/plans/2026-06-26-refresh-wall-collision-frame.md` for per-wall
+  corrected-frame evaluation.
 - See `docs/plans/2026-06-10-ci-baseline.md` for the GitHub Actions static
   baseline.
 - See `docs/plans/2026-06-09-make-gate-aliases.md` for the local gate alias guardrail.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ Helpful reports include:
 - The accelerometer availability guard must reject unsupported hardware before
   motion startup mutates generation or timing state.
 - Collision alerts should stay gated while visible so repeated collision frames do not stack duplicate modal prompts. Failure collision handling should apply a velocity reset and stop accelerometer delivery before prompting; motion startup must reject visible alerts, and dismissal should clear the alert guard and reset the frame clock before resuming. This alert pause keeps both gameplay and sensor work suspended. Previous position initialization should keep wall-collision rollback aligned with the starting point, while win completion must keep motion stopped after the exit alert.
-- Boundary and wall constraints should be resolved before exit and ghost outcomes, which must use the corrected candidate frame and stop after a terminal win.
+- Boundary and wall constraints should be resolved before exit and ghost outcomes. Each wall rollback must refresh candidate geometry before later walls are checked; outcomes must use the corrected candidate frame and stop after a terminal win.
 - `make check` runs a static baseline that guards image/XIB references, plist/scheme metadata, Xcode project wiring, shell syntax, source inventory, and local-only gameplay behavior when Xcode is unavailable.
 - GitHub Actions runs the same static baseline with Python 3.12 for pushes and
   pull requests.

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Gate collision alerts so repeated frames do not stack modal alerts
 - Reset movement velocity after failure collisions send the player to start
 - Keep previous position initialized for wall-collision rollback
+- Refresh candidate geometry after each wall rollback before checking later walls
 - Resolve physical constraints before evaluating one corrected outcome frame
 - Stop ghost outcome checks after a terminal win
 - Keep win completion as a terminal update guard after the exit alert appears
@@ -68,7 +69,8 @@ Current baseline: `make lint`, `make test`, `make build`, and `make check` run
 the unsigned app for a generic iOS simulator. The baseline verifies `build.sh`,
 plist/XIB/scheme XML, image resources, Xcode project references, accelerometer
 lifecycle and main-thread handoff guardrails, non-finite or overflow-prone motion
-sample rejection, frame time delta clamping, collision alert gating, failure
+sample rejection, frame time delta clamping, per-wall candidate-frame refresh,
+collision alert gating, failure
 velocity reset behavior, previous position initialization, win completion update
 guarding, and alert pause behavior, with local-only gameplay and alert frame
 clock reset behavior, with no debug logging, network, analytics, upload, or

--- a/docs/plans/2026-06-26-refresh-wall-collision-frame.md
+++ b/docs/plans/2026-06-26-refresh-wall-collision-frame.md
@@ -1,0 +1,45 @@
+# Refresh Wall Collision Frame
+
+status: completed
+
+## Problem
+
+`collisionWithWalls` captured one candidate frame before iterating the wall
+collection. When one wall rolled the position back, later walls in the same
+update still tested the stale pre-rollback frame and could apply an unnecessary
+second collision response.
+
+## Scope
+
+- Preserve existing wall ordering, rollback-axis selection, and velocity damping.
+- Refresh the candidate frame after each rollback before checking a later wall.
+- Keep exit and ghost outcomes on the final corrected frame.
+- Add a mutation-sensitive portable source contract.
+- Avoid XIB, asset, project-setting, motion, alert, and public API changes.
+
+## Work Completed
+
+- Recomputed `frame` from `currentPoint` after each wall collision response.
+- Required the refresh to occur after the vertical or horizontal rollback branch.
+- Updated repository guidance for sequential corrected wall geometry.
+
+## Verification Completed
+
+- The new baseline contract failed before implementation with
+  `wall collision handling must refresh the candidate frame after rollback before checking later walls`.
+- `python3 scripts/check-baseline.py` passed after implementation.
+- `/usr/bin/make lint`, `/usr/bin/make test`, `/usr/bin/make build`, and
+  `/usr/bin/make check` passed from the checkout and through the absolute
+  Makefile path from `/tmp`.
+- `python3 -m py_compile scripts/check-baseline.py`,
+  `sh -n scripts/run-motion-validation-tests.sh`, `sh -n build.sh`, and
+  `git diff --check` passed.
+- Three isolated hostile mutations were rejected: removing the refresh, moving
+  it before the rollback branch, and moving it outside the collision branch.
+- `xcodebuild` was unavailable locally and skipped explicitly; hosted macOS CI
+  is the Objective-C compile boundary.
+
+## Scope Boundaries
+
+- No wall layout, collision axis, damping constant, motion sampling, alert
+  lifecycle, outcome ordering, persistence, networking, or telemetry changed.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -29,6 +29,7 @@ MOTION_TEST_PLAN = ROOT / "docs/plans/2026-06-16-executable-motion-validation-te
 ACTIVE_MOTION_PLAN = ROOT / "docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md"
 ACCELEROMETER_AVAILABILITY_PLAN = ROOT / "docs/plans/2026-06-18-accelerometer-availability-guard.md"
 ALERT_MOTION_PLAN = ROOT / "docs/plans/2026-06-25-pause-motion-during-alerts.md"
+WALL_FRAME_REFRESH_PLAN = ROOT / "docs/plans/2026-06-26-refresh-wall-collision-frame.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -133,6 +134,7 @@ def main():
         "docs/plans/2026-06-16-executable-motion-validation-tests.md",
         "docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md",
         "docs/plans/2026-06-25-pause-motion-during-alerts.md",
+        "docs/plans/2026-06-26-refresh-wall-collision-frame.md",
         "docs/readme-overview.svg",
         "Tests/APPMotionValidationTests.c",
         "scripts/run-motion-validation-tests.sh",
@@ -202,6 +204,7 @@ def main():
     active_motion_plan = ACTIVE_MOTION_PLAN.read_text(encoding="utf-8") if ACTIVE_MOTION_PLAN.exists() else ""
     accelerometer_availability_plan = ACCELEROMETER_AVAILABILITY_PLAN.read_text(encoding="utf-8") if ACCELEROMETER_AVAILABILITY_PLAN.exists() else ""
     alert_motion_plan = ALERT_MOTION_PLAN.read_text(encoding="utf-8") if ALERT_MOTION_PLAN.exists() else ""
+    wall_frame_refresh_plan = WALL_FRAME_REFRESH_PLAN.read_text(encoding="utf-8") if WALL_FRAME_REFRESH_PLAN.exists() else ""
 
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
@@ -427,6 +430,18 @@ def main():
             view_controller.count("CGRectIntersectsRect(pacmanFrame,") == 4 and "collsionWithWalls" not in view_controller,
             "outcome collisions must use the corrected candidate frame and the wall handler must keep its corrected spelling",
             failures)
+    wall_method = view_controller[
+        view_controller.find("- (void)collisionWithWalls"):
+        view_controller.find("- (void)update", view_controller.find("- (void)collisionWithWalls"))
+    ]
+    wall_collision_index = wall_method.find("if (CGRectIntersectsRect(frame, image.frame)) {")
+    wall_collision_end_index = wall_method.find("\n       }", wall_collision_index)
+    wall_resolution_index = wall_method.find("self.pacmanYVelocity = -(self.pacmanYVelocity / 2.0);")
+    wall_frame_refresh_index = wall_method.find("frame = [self candidatePacmanFrame];", wall_resolution_index)
+    require(wall_collision_index != -1 and wall_resolution_index != -1 and
+            wall_resolution_index < wall_frame_refresh_index < wall_collision_end_index,
+            "wall collision handling must refresh the candidate frame after rollback before checking later walls",
+            failures)
     require(not re.search(r"\b(?:NSLog|printf)\s*\(", source),
             "Gameplay source must not use debug console logging",
             failures)
@@ -459,6 +474,12 @@ def main():
             "startMotionUpdates" in alert_motion_plan and
             "hostile mutations" in alert_motion_plan.lower(),
             "collision-alert motion plan must record completed pause/resume verification",
+            failures)
+    require("status: completed" in wall_frame_refresh_plan and
+            "candidate frame" in wall_frame_refresh_plan.lower() and
+            "later wall" in wall_frame_refresh_plan.lower() and
+            "hostile mutations" in wall_frame_refresh_plan.lower(),
+            "wall frame refresh plan must record completed verification",
             failures)
     require("docs/plans/2026-06-16-executable-motion-validation-tests.md" in readme and
             "executable C" in readme,


### PR DESCRIPTION
## Summary
- Refresh Pac-Man's candidate frame after each wall rollback.
- Ensure later wall checks use corrected rather than stale geometry.
- Add a mutation-sensitive source contract and synchronized maintenance guidance.

## Baseline
The collision loop computed one candidate frame before checking every wall, so a rollback against an earlier wall could leave later checks evaluating stale geometry.

## Improvements
Each rollback now refreshes the candidate frame before subsequent wall checks, preserving the existing collision axis and damping behavior while making multi-wall resolution use current geometry.

## Validation
- Red phase: the new baseline contract rejected the original single-frame wall loop.
- `python3 scripts/check-baseline.py`
- `python3 -m py_compile scripts/check-baseline.py`
- `sh -n scripts/run-motion-validation-tests.sh`
- `sh -n build.sh`
- All four Make aliases from the checkout.
- All four Make aliases from `/tmp` through the absolute Makefile path.
- Three isolated hostile mutations rejected.
- `git diff --check`

## Risk
Local `xcodebuild` is unavailable; hosted macOS validation remains authoritative for Objective-C compilation. No wall layout, collision axis, damping, motion, alert, outcome, persistence, network, or telemetry behavior changed.

## Follow-Ups
Retain executable motion tests and the mutation-sensitive frame-refresh contract whenever collision ordering or rollback behavior changes.
