### PR TITLE
Require active app state for motion startup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,39 @@
 # Changes
 
+## 2026-06-26 13:29 PDT - P1 - Require active app motion startup
+
+### Summary
+Motion startup requires UIApplicationStateActive at the controller boundary.
+
+### Work completed
+- Added the active-state check to the shared `startMotionUpdates` guard so app
+  delegate resume and alert dismissal cannot bypass lifecycle ownership.
+- Kept the guard ahead of motion generation, frame clock, and callback startup.
+- Added maintained source, documentation, and completed-plan contracts.
+
+### Validation
+- Red phase: the static baseline rejected the missing controller-owned active-state guard.
+- `make check` passed the executable C harness and static baseline;
+  `xcodebuild` was unavailable locally and skipped explicitly.
+- Two isolated hostile mutations removing the active-state guard or its
+  documented contract were rejected.
+- Both hosted baseline jobs passed; CodeQL Actions, C/C++, and Python analyses
+  also passed.
+- `git diff --check` passed.
+- Codex review targeted `origin/master` but failed HTTP 401 before analysis;
+  immutable manual review found no actionable issue.
+
+### Bugs / findings
+- P1: direct callers such as alert dismissal could request motion restart after
+  lifecycle callbacks had already paused the inactive application.
+
+### Blockers
+- Hosted macOS CI remains authoritative for Objective-C/UIKit compilation.
+- External Codex review authentication remains unavailable.
+
+### Next action
+- Open the PR, run Codex review, and merge only after hosted checks pass.
+
 ## 2026-06-26 - P2 - Refresh wall collision geometry
 
 ### Summary

--- a/Maze/APPViewController.m
+++ b/Maze/APPViewController.m
@@ -66,6 +66,7 @@
 - (void)startMotionUpdates {
     if (self.gameCompleted
         || self.collisionAlertVisible
+        || [UIApplication sharedApplication].applicationState != UIApplicationStateActive
         || ![self.motionManager isAccelerometerAvailable]
         || [self.motionManager isAccelerometerActive]) {
         return;

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   or overflow-prone motion samples should be rejected, updates should follow the
   active app lifecycle, and stale queued motion should not cross pause/resume
   boundaries.
+- Motion startup requires UIApplicationStateActive at the controller boundary.
 - Ghost collision alerts stop accelerometer delivery while the modal prompt is
   visible. Dismissal clears the alert guard, refreshes the frame clock, and then
   resumes motion; terminal win alerts remain stopped.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,7 @@ Helpful reports include:
   stale queued motion across pause/resume boundaries.
 - The accelerometer availability guard must reject unsupported hardware before
   motion startup mutates generation or timing state.
+- Motion startup requires UIApplicationStateActive at the controller boundary.
 - Collision alerts should stay gated while visible so repeated collision frames do not stack duplicate modal prompts. Failure collision handling should apply a velocity reset and stop accelerometer delivery before prompting; motion startup must reject visible alerts, and dismissal should clear the alert guard and reset the frame clock before resuming. This alert pause keeps both gameplay and sensor work suspended. Previous position initialization should keep wall-collision rollback aligned with the starting point, while win completion must keep motion stopped after the exit alert.
 - Boundary and wall constraints should be resolved before exit and ghost outcomes. Each wall rollback must refresh candidate geometry before later walls are checked; outcomes must use the corrected candidate frame and stop after a terminal win.
 - `make check` runs a static baseline that guards image/XIB references, plist/scheme metadata, Xcode project wiring, shell syntax, source inventory, and local-only gameplay behavior when Xcode is unavailable.

--- a/VISION.md
+++ b/VISION.md
@@ -19,6 +19,7 @@ Priority:
 - Keep the screenshot and README aligned with app behavior
 - Maintain the build script and Xcode project structure
 - Keep accelerometer updates bounded to the active app lifecycle
+- Motion startup requires UIApplicationStateActive at the controller boundary.
 - Stop accelerometer delivery while collision alerts own the game screen, and
   resume only after dismissal clears the alert guard
 - Keep the accelerometer availability guard ahead of motion startup state

--- a/docs/plans/2026-06-26-active-motion-start-guard.md
+++ b/docs/plans/2026-06-26-active-motion-start-guard.md
@@ -1,0 +1,26 @@
+# Active Motion Start Guard
+
+Status: Completed
+
+## Goal
+
+Make active application state an invariant of the controller-owned motion
+startup boundary rather than an assumption of individual callers.
+
+## Scope
+
+- Reject startup unless `UIApplicationStateActive` owns the screen.
+- Keep the check before generation, clock, queue, and handler side effects.
+- Preserve availability, duplicate-start, alert, and terminal-game guards.
+- Keep app delegate and alert dismissal callers unchanged.
+
+## Verification
+
+- Prove the missing guard with the static baseline.
+- Run `make check` and isolated hostile mutations.
+- Run hosted Xcode build and CodeQL before merge.
+- Run `git diff --check` and exact-head review.
+
+## Outcome
+
+Every motion restart path now fails closed while the application is inactive.

--- a/scripts/check-baseline.py
+++ b/scripts/check-baseline.py
@@ -30,6 +30,7 @@ ACTIVE_MOTION_PLAN = ROOT / "docs/plans/2026-06-17-018-fix-active-motion-lifecyc
 ACCELEROMETER_AVAILABILITY_PLAN = ROOT / "docs/plans/2026-06-18-accelerometer-availability-guard.md"
 ALERT_MOTION_PLAN = ROOT / "docs/plans/2026-06-25-pause-motion-during-alerts.md"
 WALL_FRAME_REFRESH_PLAN = ROOT / "docs/plans/2026-06-26-refresh-wall-collision-frame.md"
+ACTIVE_START_GUARD_PLAN = ROOT / "docs/plans/2026-06-26-active-motion-start-guard.md"
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
@@ -135,6 +136,7 @@ def main():
         "docs/plans/2026-06-17-018-fix-active-motion-lifecycle-plan.md",
         "docs/plans/2026-06-25-pause-motion-during-alerts.md",
         "docs/plans/2026-06-26-refresh-wall-collision-frame.md",
+        "docs/plans/2026-06-26-active-motion-start-guard.md",
         "docs/readme-overview.svg",
         "Tests/APPMotionValidationTests.c",
         "scripts/run-motion-validation-tests.sh",
@@ -205,6 +207,21 @@ def main():
     accelerometer_availability_plan = ACCELEROMETER_AVAILABILITY_PLAN.read_text(encoding="utf-8") if ACCELEROMETER_AVAILABILITY_PLAN.exists() else ""
     alert_motion_plan = ALERT_MOTION_PLAN.read_text(encoding="utf-8") if ALERT_MOTION_PLAN.exists() else ""
     wall_frame_refresh_plan = WALL_FRAME_REFRESH_PLAN.read_text(encoding="utf-8") if WALL_FRAME_REFRESH_PLAN.exists() else ""
+    active_start_guard_plan = ACTIVE_START_GUARD_PLAN.read_text(encoding="utf-8") if ACTIVE_START_GUARD_PLAN.exists() else ""
+
+    active_start_contract = "Motion startup requires UIApplicationStateActive at the controller boundary."
+    for path, source_text in [
+        ("README.md", readme),
+        ("SECURITY.md", security),
+        ("VISION.md", vision),
+        ("CHANGES.md", changes),
+    ]:
+        require(active_start_contract in source_text,
+                f"{path} must keep the active motion start contract", failures)
+    require("Status: Completed" in active_start_guard_plan and
+            "make check" in active_start_guard_plan,
+            "active motion start guard plan must record completed verification",
+            failures)
 
     shell_result = subprocess.run(["sh", "-n", "build.sh"], cwd=str(ROOT), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     require(shell_result.returncode == 0,
@@ -264,11 +281,15 @@ def main():
     stop_method_index = view_controller.find("- (void)stopMotionUpdates")
     callback_index = view_controller.find("startAccelerometerUpdatesToQueue:self.queue withHandler:")
     duplicate_start_guard_index = view_controller.find(
-        "if (self.gameCompleted\n        || self.collisionAlertVisible\n        || ![self.motionManager isAccelerometerAvailable]\n        || [self.motionManager isAccelerometerActive]) {",
+        "if (self.gameCompleted\n        || self.collisionAlertVisible\n        || [UIApplication sharedApplication].applicationState != UIApplicationStateActive\n        || ![self.motionManager isAccelerometerAvailable]\n        || [self.motionManager isAccelerometerActive]) {",
         start_method_index,
     )
     availability_guard_index = view_controller.find(
         "![self.motionManager isAccelerometerAvailable]",
+        start_method_index,
+    )
+    active_application_guard_index = view_controller.find(
+        "[UIApplication sharedApplication].applicationState != UIApplicationStateActive",
         start_method_index,
     )
     generation_increment_index = view_controller.find(
@@ -298,10 +319,10 @@ def main():
             "@property (assign, nonatomic) NSUInteger motionUpdateGeneration;" in view_controller and
             "startAccelerometerUpdatesToQueue" not in view_did_load and
             start_method_index != -1 and stop_method_index != -1 and
-            duplicate_start_guard_index != -1 and availability_guard_index != -1 and
+            duplicate_start_guard_index != -1 and active_application_guard_index != -1 and availability_guard_index != -1 and
             generation_increment_index != -1 and
             generation_capture_index != -1 and resume_clock_index != -1 and callback_index != -1 and
-            start_method_index < duplicate_start_guard_index <= availability_guard_index < generation_increment_index < generation_capture_index < resume_clock_index < callback_index and
+            start_method_index < duplicate_start_guard_index <= active_application_guard_index < availability_guard_index < generation_increment_index < generation_capture_index < resume_clock_index < callback_index and
             "self.motionUpdateGeneration += 1;" in stop_method and
             "[self.motionManager stopAccelerometerUpdates];" in stop_method,
             "motion ownership must use idempotent controller start/stop methods with generation invalidation and a fresh resume clock",


### PR DESCRIPTION
## Summary
- require active application state inside the controller-owned motion start guard
- prevent alert dismissal or direct callers from restarting sensors while inactive
- add mutation-sensitive source and documentation contracts

## Baseline
The controller could satisfy its visible-screen conditions while the application was inactive, allowing direct motion-start callers to restart accelerometer updates at the wrong lifecycle boundary.

## Improvements
- require `UIApplicationStateActive` before starting motion updates
- preserve accelerometer availability, visibility, and single-stream ownership guards
- document and statically enforce the active-state startup boundary

## Validation
- merged master `0bb21b0b0f598a899560667b462728ad20f30267` passed `lint`, `test`, `build`, and `check`
- each alias executed the shared C motion-validation harness and Objective-C static baseline
- Gitleaks found no secrets in the current tree or all 60 commits
- both hosted macOS baselines passed
- CodeQL passed for Actions, C/C++, and Python

## Risk
Low. The change tightens motion startup lifecycle eligibility without changing valid active gameplay. Local Linux cannot compile the Xcode project or exercise CoreMotion hardware.

## Follow-Ups
- preserve active-state, visibility, availability, and single-stream guards when adding motion restart paths